### PR TITLE
Update Get-WinADDFSHealth.ps1 SYSVol Count

### DIFF
--- a/Public/Get-WinADDFSHealth.ps1
+++ b/Public/Get-WinADDFSHealth.ps1
@@ -125,7 +125,7 @@
             }
 
             try {
-                [Array] $SYSVOL = Get-ChildItem -Path "\\$Hostname\SYSVOL\$Domain\Policies" -ErrorAction Stop
+                [Array] $SYSVOL = Get-ChildItem -Path "\\$Hostname\SYSVOL\$Domain\Policies" -Exclude "PolicyDefinitions*" -ErrorAction Stop
                 $DomainSummary['SysvolCount'] = $SYSVOL.Count
             } catch {
                 $DomainSummary['SysvolCount'] = 0


### PR DESCRIPTION
Adjust the SYSVOL/GPO count comparison to exclude PolicyDefinition Folders