### PR TITLE
Refactor + -HideHTML parameter

### DIFF
--- a/Public/Show-WinADGroupMember.ps1
+++ b/Public/Show-WinADGroupMember.ps1
@@ -10,11 +10,25 @@
         [switch] $HideOther,
         [Parameter(ParameterSetName = 'Default')][switch] $Summary,
         [Parameter(ParameterSetName = 'SummaryOnly')][switch] $SummaryOnly,
-        [switch] $Online
+        [switch] $Online,
+        [switch] $HideHTML
     )
     if ($FilePath -eq '') {
         $FilePath = Get-FileName -Extension 'html' -Temporary
     }
+
+    if ($PSBoundParameters.ContainsKey('HideHTML')) {
+        $ShowHTML = $false
+    } else {
+        $ShowHTML = $true
+    }
+
+    $params = @{
+        FilePath = $FilePath
+        ShowHTML = $ShowHTML
+        Online = $Online
+    }
+
     $GroupsList = [System.Collections.Generic.List[object]]::new()
     New-HTML -TitleText "Visual Group Membership" {
         New-HTMLSectionStyle -BorderRadius 0px -HeaderBackGroundColor Grey -RemoveShadow
@@ -78,5 +92,9 @@
                 }
             }
         }
-    } -Online:$Online -FilePath $FilePath -ShowHTML
+    }  @params
+
+        if ($PSBoundParameters.ContainsKey('HideHTML')) {
+            return $FilePath
+        }
 }


### PR DESCRIPTION
This adds a parameter -HideHTML which effectively suppresses the file from being opened in the web browser after executing the function. In addition, by using -HideHTML will return path to the file, as it might be randomly generated - this could be used in further automation.