### PR TITLE
Limit Resolve-DnsName results to Answer section

### DIFF
--- a/Public/Get-WinADForestControllerInformation.ps1
+++ b/Public/Get-WinADForestControllerInformation.ps1
@@ -50,8 +50,8 @@ function Get-WinADForestControllerInformation {
 
             $DNS = Resolve-DnsName -DnsOnly -Name $DC.DNSHostName -ErrorAction SilentlyContinue -QuickTimeout -Verbose:$false
             if ($DNS) {
-                $ResolvedIP4 = ($DNS | Where-Object { $_.Type -eq 'A' }).IPAddress
-                $ResolvedIP6 = ($DNS | Where-Object { $_.Type -eq 'AAAA' }).IPAddress
+                $ResolvedIP4 = ($DNS | Where-Object { $_.Section -eq 'Answer' -and $_.Type -eq 'A' }).IPAddress
+                $ResolvedIP6 = ($DNS | Where-Object { $_.Section -eq 'Answer' -and $_.Type -eq 'AAAA' }).IPAddress
                 $DNSStatus = $true
             } else {
                 $ResolvedIP4 = $null


### PR DESCRIPTION
This change addresses issue #17 and adds an additional filter to the `Resolve-DnsName` results so they only include real answers rather than records from the Additional section.