### PR TITLE
Recursive control on Get-WinADSharePermission

### DIFF
--- a/Public/Get-WinADSharePermission.ps1
+++ b/Public/Get-WinADSharePermission.ps1
@@ -1,4 +1,4 @@
-﻿function Get-WinADSharePermission {
+function Get-WinADSharePermission {
     <#
     .SYNOPSIS
     Retrieves the permissions for a specified Windows Active Directory share or shares based on type.
@@ -11,6 +11,12 @@
 
     .PARAMETER ShareType
     Specifies the type of share for which to retrieve permissions. This parameter is mandatory when using the 'ShareType' parameter set. Valid values are 'NetLogon' and 'SYSVOL'.
+
+	.PARAMETER NoRecursion
+    Disables recursive querying of permissions and limits the query to the root of the sepcified path. This is a switch so no other variable is neeed. Just add `-NoRecursion`. This superceeds the `-Depth` parameter.
+
+	.PARAMETER Depth
+    Limit the depth of recursion that happens when querying a directory. Especially useful for large and complex folders with several hundred or dozen subfolders.  -1 = unlimited recursion, 0 = no recursion, 1-1023 total limit of recursion depth
 
     .PARAMETER Owner
     Specifies that the cmdlet should only return the owner of the share instead of the full permissions.
@@ -49,6 +55,8 @@
     param(
         [Parameter(ParameterSetName = 'Path', Mandatory)][string] $Path,
         [Parameter(ParameterSetName = 'ShareType', Mandatory)][validateset('NetLogon', 'SYSVOL')][string[]] $ShareType,
+        [switch]$NoRecursion,   # Prevents recursive scanning (supercedes Depth)
+        [int]$Depth = -1,       # -1 means unlimited recursion
         [switch] $Owner,
         [string[]] $Name,
         [alias('ForestName')][string] $Forest,
@@ -56,42 +64,103 @@
         [alias('Domain', 'Domains')][string[]] $IncludeDomains,
         [System.Collections.IDictionary] $ExtendedForestInformation
     )
+
     if ($ShareType) {
         $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
         foreach ($Domain in $ForestInformation.Domains) {
-            $Path = -join ("\\", $Domain, "\$ShareType")
-            @(Get-Item -Path $Path -Force) + @(Get-ChildItem -Path $Path -Recurse:$true -Force -ErrorAction SilentlyContinue -ErrorVariable Err) | ForEach-Object -Process {
-                if ($Owner) {
-                    $Output = Get-FileOwner -JustPath -Path $_ -Resolve -AsHashTable
-                    $Output['Attributes'] = $_.Attributes
-                    [PSCustomObject] $Output
-                } else {
-                    $Output = Get-FilePermission -Path $_ -ResolveTypes -Extended -AsHashTable
-                    foreach ($O in $Output) {
-                        $O['Attributes'] = $_.Attributes
-                        [PSCustomObject] $O
-                    }
-                }
-            }
+            $SharePath = "\\$Domain\$ShareType"
+            Process-SharePath -Path $SharePath -NoRecursion:$NoRecursion -Depth $Depth -Owner:$Owner
         }
     } else {
         if ($Path -and (Test-Path -Path $Path)) {
-            @(Get-Item -Path $Path -Force) + @(Get-ChildItem -Path $Path -Recurse:$true -Force -ErrorAction SilentlyContinue -ErrorVariable Err) | ForEach-Object -Process {
-                if ($Owner) {
-                    $Output = Get-FileOwner -JustPath -Path $_ -Resolve -AsHashTable -Verbose
-                    $Output['Attributes'] = $_.Attributes
-                    [PSCustomObject] $Output
-                } else {
-                    $Output = Get-FilePermission -Path $_ -ResolveTypes -Extended -AsHashTable
-                    foreach ($O in $Output) {
-                        $O['Attributes'] = $_.Attributes
-                        [PSCustomObject] $O
-                    }
-                }
+            Process-SharePath -Path $Path -NoRecursion:$NoRecursion -Depth $Depth -Owner:$Owner
+        } else {
+            Write-Warning "Path does not exist: $Path"
+        }
+    }
+}
+
+function Process-SharePath {
+    param (
+        [string]$Path,
+        [switch]$NoRecursion,
+        [int]$Depth,
+        [switch]$Owner
+    )
+
+    # Ensure the root path is always included
+    $items = @()
+    if (Test-Path -Path $Path) {
+        $items += Get-Item -Path $Path -Force  # Always include the root folder
+    }
+
+    # Get subdirectories based on recursion settings
+    if (-not $NoRecursion) {
+        if ($Depth -ge 0) {
+            $items += Get-ChildItem -Path $Path -Directory -Depth $Depth -Force -ErrorAction SilentlyContinue
+        } else {
+            $items += Get-ChildItem -Path $Path -Directory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Process each item
+    $items | ForEach-Object -Process {
+        if ($Owner) {
+            $Output = Get-FileOwner -JustPath -Path $_.FullName -Resolve -AsHashTable
+            $Output['Attributes'] = $_.Attributes
+            [PSCustomObject] $Output
+        } else {
+            $Output = Get-FilePermission -Path $_.FullName -ResolveTypes -Extended -AsHashTable
+            foreach ($O in $Output) {
+                $O['Attributes'] = $_.Attributes
+                [PSCustomObject] $O
             }
         }
     }
-    foreach ($e in $err) {
-        Write-Warning "Get-WinADSharePermission - $($e.Exception.Message) ($($e.CategoryInfo.Reason))"
+}
+
+# Helper function to process permissions
+function Get-PermissionsForPath {
+    param(
+        [string] $Path,
+        [switch] $NoRecursion,
+        [int] $Depth,
+        [switch] $Owner
+    )
+
+    try {
+        $targetItem = Get-Item -Path $Path -Force -ErrorAction Stop
+    } catch {
+        Write-Warning "Get-PermissionsForPath - Failed to get item '$Path': $($_.Exception.Message)"
+        return
+    }
+
+    # Determine child items based on recursion settings
+    $childItems = if ($NoRecursion) {
+        @()
+    } elseif ($Depth -ge 0) {
+        Get-ChildItem -Path $Path -Recurse -Depth $Depth -Force -ErrorAction SilentlyContinue
+    } else {
+        Get-ChildItem -Path $Path -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $items = @($targetItem) + $childItems
+
+    foreach ($item in $items) {
+        try {
+            if ($Owner) {
+                $Output = Get-FileOwner -JustPath -Path $item.FullName -Resolve -AsHashTable -ErrorAction Stop
+                $Output['Attributes'] = $item.Attributes
+                [PSCustomObject] $Output
+            } else {
+                $Output = Get-FilePermission -Path $item.FullName -ResolveTypes -Extended -AsHashTable -ErrorAction Stop
+                foreach ($O in $Output) {
+                    $O['Attributes'] = $item.Attributes
+                    [PSCustomObject] $O
+                }
+            }
+        } catch {
+            Write-Warning "Get-PermissionsForPath - Failed to process '$($item.FullName)': $($_.Exception.Message)"
+        }
     }
 }


### PR DESCRIPTION
Added the following parameters:
-NoRecursion
-Depth (values -1 to technically up to 1023)
These allow you to limit how deep Get-WinADSharePermissions will go when querying permissions.