### PR TITLE
 Improvements to Show/Get forest replication/subnet

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,10 @@
-﻿#### 0.0.236
+﻿#### 0.0.237
+- Improve `Get-WinADForestSubnet`
+  - Added handling for CNF objects
+  - Improved error handling for IP address and integer conversions
+  - Added better warning messages for malformed subnets
+
+#### 0.0.236
 - Improved `Show-WinADForestReplicationSummary`
 
 #### 0.0.235

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
   - Added handling for CNF objects
   - Improved error handling for IP address and integer conversions
   - Added better warning messages for malformed subnets
+- Improved `Show-WinADForestReplicationSummary`
 
 #### 0.0.236
 - Improved `Show-WinADForestReplicationSummary`

--- a/Public/Get-WinADForestReplication.ps1
+++ b/Public/Get-WinADForestReplication.ps1
@@ -37,7 +37,7 @@
     Skips the sites and subnets information.
 
     .PARAMETER All
-    Indicates whether to include all domain controllers in the replication search.
+    Indicates whether to include all information in the output.
 
     .EXAMPLE
     Get-WinADForestReplication -Forest "example.com" -IncludeDomains @("example.com") -ExcludeDomains @("test.com") -IncludeDomainControllers @("DC1") -ExcludeDomainControllers @("DC2") -SkipRODC -Extended -ExtendedForestInformation $ExtendedForestInfo

--- a/Public/Get-WinADForestReplication.ps1
+++ b/Public/Get-WinADForestReplication.ps1
@@ -30,6 +30,15 @@
     .PARAMETER ExtendedForestInformation
     Specifies additional information about the forest for replication.
 
+    .PARAMETER SkipReplicationTopology
+    Skips the replication topology information.
+
+    .PARAMETER SkipSitesSubnets
+    Skips the sites and subnets information.
+
+    .PARAMETER All
+    Indicates whether to include all domain controllers in the replication search.
+
     .EXAMPLE
     Get-WinADForestReplication -Forest "example.com" -IncludeDomains @("example.com") -ExcludeDomains @("test.com") -IncludeDomainControllers @("DC1") -ExcludeDomainControllers @("DC2") -SkipRODC -Extended -ExtendedForestInformation $ExtendedForestInfo
 
@@ -45,12 +54,19 @@
         [alias('DomainControllers')][string[]] $IncludeDomainControllers,
         [switch] $SkipRODC,
         [switch] $Extended,
+        [switch] $SkipReplicationTopology,
+        [switch] $SkipSitesSubnets,
         [switch] $All,
         [System.Collections.IDictionary] $ExtendedForestInformation
     )
     $ProcessErrors = [System.Collections.Generic.List[PSCustomObject]]::new()
     $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExcludeDomainControllers $ExcludeDomainControllers -IncludeDomainControllers $IncludeDomainControllers -SkipRODC:$SkipRODC -ExtendedForestInformation $ExtendedForestInformation
+
+    Write-Verbose -Message "Get-WinADForestReplication - Getting replication information for forest $($ForestInformation.Forest.Name)"
+    $Count = 0
     $Replication = foreach ($DC in $ForestInformation.ForestDomainControllers) {
+        $Count++
+        Write-Verbose -Message "Get-WinADForestReplication - Getting replication information for server [$Count/$($ForestInformation.ForestDomainControllers.Count)] $($DC.HostName)"
         try {
             Get-ADReplicationPartnerMetadata -Target $DC.HostName -Partition * -ErrorAction Stop #-ErrorVariable +ProcessErrors
         } catch {
@@ -58,7 +74,9 @@
             $ProcessErrors.Add([PSCustomObject] @{ Server = $_.Exception.ServerName; StatusMessage = $_.Exception.Message })
         }
     }
+    Write-Verbose -Message "Get-WinADForestReplication - Finished getting replication information for forest $($ForestInformation.Forest.Name)"
     [Array] $ReplicationData = @(
+        Write-Verbose -Message "Get-WinADForestReplication - Processing replication data for forest $($ForestInformation.Forest.Name)"
         foreach ($R in $Replication) {
             $ServerPartner = (Resolve-DnsName -Name $R.PartnerAddress -Verbose:$false -ErrorAction SilentlyContinue)
             $ServerInitiating = (Resolve-DnsName -Name $R.Server -Verbose:$false -ErrorAction SilentlyContinue)
@@ -147,14 +165,23 @@
         }
     )
 
+    if ($SkipReplicationTopology -and $SkipSitesSubnets) {
+        return $ReplicationData
+    }
     if (-not $All) {
         return $ReplicationData
     }
 
     $SiteInformation = @{}
-
+    Write-Verbose -Message "Get-WinADForestReplication - Getting site information for forest $($ForestInformation.Forest.Name)"
     $Sites = Get-WinADForestSites
-    $Subnets = Get-WinADForestSubnet -VerifyOverlap
+
+    if (-not $SkipSitesSubnets) {
+        Write-Verbose -Message "Get-WinADForestReplication - Getting subnet information for forest $($ForestInformation.Forest.Name)"
+        $Subnets = Get-WinADForestSubnet -VerifyOverlap
+    } else {
+        $Subnets = @()
+    }
 
     # Build a mapping of DC names to their sites
     foreach ($Site in $Sites) {
@@ -167,119 +194,122 @@
 
     $DCs = @{}
     $Links = [System.Collections.Generic.List[object]]::new()
+    $ReplicationMatrix = [System.Collections.Generic.List[PSCustomObject]]::new()
 
-    foreach ($RepLink in $ReplicationData) {
-        # Ensure Server and Partner are added as nodes
-        if ($RepLink.Server -and -not $DCs.ContainsKey($RepLink.Server)) {
-            $DCs[$RepLink.Server] = @{
-                Label    = $RepLink.Server
-                IP       = $RepLink.ServerIPV4
-                Partners = [System.Collections.Generic.HashSet[string]]::new()
-                Status   = $true  # Will be set to false if any replication link fails
+    if (-not $SkipReplicationTopology) {
+        Write-Verbose -Message "Get-WinADForestReplication - Building replication topology for forest $($ForestInformation.Forest.Name)"
+        foreach ($RepLink in $ReplicationData) {
+            # Ensure Server and Partner are added as nodes
+            if ($RepLink.Server -and -not $DCs.ContainsKey($RepLink.Server)) {
+                $DCs[$RepLink.Server] = @{
+                    Label    = $RepLink.Server
+                    IP       = $RepLink.ServerIPV4
+                    Partners = [System.Collections.Generic.HashSet[string]]::new()
+                    Status   = $true  # Will be set to false if any replication link fails
+                }
+            }
+            if ($RepLink.ServerPartner -and -not $DCs.ContainsKey($RepLink.ServerPartner)) {
+                # Attempt to resolve partner IP if not directly available (may require another lookup or be less reliable)
+                $PartnerIP = $RepLink.ServerPartnerIPV4 # Use the IP already resolved by Get-WinADForestReplication
+                $DCs[$RepLink.ServerPartner] = @{
+                    Label    = $RepLink.ServerPartner
+                    IP       = $PartnerIP
+                    Partners = [System.Collections.Generic.HashSet[string]]::new()
+                    Status   = $true
+                }
+            }
+
+            # Add partner to the server's partner list (using HashSet to avoid duplicates)
+            if ($RepLink.Server -and $RepLink.ServerPartner) {
+                $null = $DCs[$RepLink.Server].Partners.Add($RepLink.ServerPartner)
+
+                # Update status if there's any failure
+                if (-not $RepLink.Status) {
+                    $DCs[$RepLink.Server].Status = $false
+                }
+            }
+
+            # Add the link (handle potential duplicates if needed, maybe group by Server/Partner/Partition?)
+            # For simplicity now, add each link found. Diagram might show multiple lines if partitions differ.
+            if ($RepLink.Server -and $RepLink.ServerPartner) {
+                $Links.Add(@{
+                        From        = $RepLink.Server
+                        To          = $RepLink.ServerPartner
+                        Status      = $RepLink.Status
+                        Fails       = $RepLink.ConsecutiveReplicationFailures
+                        LastSuccess = $RepLink.LastReplicationSuccess
+                        Partition   = $RepLink.Partition
+                    })
             }
         }
-        if ($RepLink.ServerPartner -and -not $DCs.ContainsKey($RepLink.ServerPartner)) {
-            # Attempt to resolve partner IP if not directly available (may require another lookup or be less reliable)
-            $PartnerIP = $RepLink.ServerPartnerIPV4 # Use the IP already resolved by Get-WinADForestReplication
-            $DCs[$RepLink.ServerPartner] = @{
-                Label    = $RepLink.ServerPartner
-                IP       = $PartnerIP
-                Partners = [System.Collections.Generic.HashSet[string]]::new()
-                Status   = $true
-            }
-        }
 
-        # Add partner to the server's partner list (using HashSet to avoid duplicates)
-        if ($RepLink.Server -and $RepLink.ServerPartner) {
-            $null = $DCs[$RepLink.Server].Partners.Add($RepLink.ServerPartner)
-
-            # Update status if there's any failure
-            if (-not $RepLink.Status) {
-                $DCs[$RepLink.Server].Status = $false
-            }
-        }
-
-        # Add the link (handle potential duplicates if needed, maybe group by Server/Partner/Partition?)
-        # For simplicity now, add each link found. Diagram might show multiple lines if partitions differ.
-        if ($RepLink.Server -and $RepLink.ServerPartner) {
-            $Links.Add(@{
-                    From        = $RepLink.Server
-                    To          = $RepLink.ServerPartner
-                    Status      = $RepLink.Status
-                    Fails       = $RepLink.ConsecutiveReplicationFailures
-                    LastSuccess = $RepLink.LastReplicationSuccess
-                    Partition   = $RepLink.Partition
-                })
-        }
-    }
-
-    # Create consolidated view of DC replication partnerships
-    $DCPartnerSummary = foreach ($DCName in $DCs.Keys) {
-        $DC = $DCs[$DCName]
-        [PSCustomObject]@{
-            DomainController = $DCName
-            Site             = $SiteInformation[$DCName]
-            IPAddress        = $DC.IP
-            Partners         = $DC.Partners | ForEach-Object { $_ }
-            PartnerCount     = $DC.Partners.Count
-            PartnerSites     = @(
-                foreach ($Partner in $DC.Partners) {
-                    if ($SiteInformation.ContainsKey($Partner)) {
-                        $SiteInformation[$Partner]
+        # Create consolidated view of DC replication partnerships
+        $DCPartnerSummary = foreach ($DCName in $DCs.Keys) {
+            $DC = $DCs[$DCName]
+            [PSCustomObject]@{
+                DomainController = $DCName
+                Site             = $SiteInformation[$DCName]
+                IPAddress        = $DC.IP
+                Partners         = $DC.Partners | ForEach-Object { $_ }
+                PartnerCount     = $DC.Partners.Count
+                PartnerSites     = @(
+                    foreach ($Partner in $DC.Partners) {
+                        if ($SiteInformation.ContainsKey($Partner)) {
+                            $SiteInformation[$Partner]
+                        } else {
+                            "Unknown"
+                        }
+                    }
+                ) | Sort-Object -Unique
+                PartnersIP       = $DC.Partners | ForEach-Object {
+                    if ($DCs.ContainsKey($_)) {
+                        $DCs[$_].IP
                     } else {
                         "Unknown"
                     }
-                }
-            ) | Sort-Object -Unique
-            PartnersIP       = $DC.Partners | ForEach-Object {
-                if ($DCs.ContainsKey($_)) {
-                    $DCs[$_].IP
-                } else {
-                    "Unknown"
-                }
-            } | Sort-Object -Unique
-            Status           = if ($DC.Status) { "Healthy" } else { "Issues Detected" }
-        }
-    }
-
-    # Create a matrix-style mapping of DCs to their replication partners
-    $DCNames = $DCs.Keys | Sort-Object
-    $MatrixHeaders = $DCNames
-    $ReplicationMatrix = [System.Collections.Generic.List[PSCustomObject]]::new()
-
-    foreach ($SourceDC in $DCNames) {
-        $Row = [ordered]@{
-            'Source DC'    = $SourceDC
-            'Site'         = $SiteInformation[$SourceDC]
-            'IP'           = $DCs[$SourceDC].IP
-            'PartnerCount' = $DCs[$SourceDC].Partners.Count
-        }
-
-        foreach ($TargetDC in $DCNames) {
-            if ($SourceDC -eq $TargetDC) {
-                # A DC doesn't replicate with itself
-                $Row[$TargetDC] = "-"
-            } else {
-                # Check if there are any replication links from Source to Target
-                $ReplicationLinks = $Links | Where-Object { $_.From -eq $SourceDC -and $_.To -eq $TargetDC }
-
-                if ($ReplicationLinks) {
-                    $AllHealthy = $true
-                    foreach ($Link in $ReplicationLinks) {
-                        if (-not $Link.Status) {
-                            $AllHealthy = $false
-                            break
-                        }
-                    }
-
-                    $Row[$TargetDC] = if ($AllHealthy) { "✓" } else { "✗" }
-                } else {
-                    $Row[$TargetDC] = " "  # No direct replication
-                }
+                } | Sort-Object -Unique
+                Status           = if ($DC.Status) { "Healthy" } else { "Issues Detected" }
             }
         }
 
-        $ReplicationMatrix.Add([PSCustomObject]$Row)
+        # Create a matrix-style mapping of DCs to their replication partners
+        $DCNames = $DCs.Keys | Sort-Object
+        $MatrixHeaders = $DCNames
+
+        foreach ($SourceDC in $DCNames) {
+            $Row = [ordered]@{
+                'Source DC'    = $SourceDC
+                'Site'         = $SiteInformation[$SourceDC]
+                'IP'           = $DCs[$SourceDC].IP
+                'PartnerCount' = $DCs[$SourceDC].Partners.Count
+            }
+
+            foreach ($TargetDC in $DCNames) {
+                if ($SourceDC -eq $TargetDC) {
+                    # A DC doesn't replicate with itself
+                    $Row[$TargetDC] = "-"
+                } else {
+                    # Check if there are any replication links from Source to Target
+                    $ReplicationLinks = $Links | Where-Object { $_.From -eq $SourceDC -and $_.To -eq $TargetDC }
+
+                    if ($ReplicationLinks) {
+                        $AllHealthy = $true
+                        foreach ($Link in $ReplicationLinks) {
+                            if (-not $Link.Status) {
+                                $AllHealthy = $false
+                                break
+                            }
+                        }
+
+                        $Row[$TargetDC] = if ($AllHealthy) { "✓" } else { "✗" }
+                    } else {
+                        $Row[$TargetDC] = " "  # No direct replication
+                    }
+                }
+            }
+
+            $ReplicationMatrix.Add([PSCustomObject]$Row)
+        }
     }
 
     [ordered] @{

--- a/Public/Get-WinADForestSubnet.ps1
+++ b/Public/Get-WinADForestSubnet.ps1
@@ -30,6 +30,10 @@
         [switch] $VerifyOverlap
     )
     $ForestInformation = Get-WinADForestDetails -Forest $Forest -ExtendedForestInformation $ExtendedForestInformation
+    if (-not $ForestInformation) {
+        Write-Warning "Get-WinADForestSubnet - Unable to retrieve forest information for $Forest"
+        return
+    }
     $QueryServer = $ForestInformation.QueryServers[$($ForestInformation.Forest.Name)]['HostName'][0]
     $ForestDN = ConvertTo-DistinguishedName -ToDomain -CanonicalName $ForestInformation.Forest.Name
 

--- a/Public/Show-WinADForestReplicationSummary.ps1
+++ b/Public/Show-WinADForestReplicationSummary.ps1
@@ -19,6 +19,25 @@
     .PARAMETER PassThru
     Switch to return the replication summary and statistics as output.
 
+    .PARAMETER SummaryOnly
+    Switch to indicate if only the summary should be returned.
+
+    .PARAMETER SkipReplicationTopology
+    Switch to indicate if the replication topology should be skipped.
+
+    .PARAMETER SkipReplicationTopologyDiagram
+    Switch to indicate if the replication topology diagram should be skipped.
+
+    .PARAMETER SkipSitesSubnets
+    Switch to indicate if the sites and subnets information should be skipped.
+
+    .PARAMETER SkipSitesSubnetsDiagram
+    Switch to indicate if the sites and subnets diagram should be skipped.
+
+    .PARAMETER DiagramSitesSubnetsNodes
+    Specifies the nodes to be included in the sites and subnets diagram. Valid values are 'DC' and 'Subnet'.
+    Default is both.
+
     .EXAMPLE
     Show-WinADForestReplicationSummary -FilePath "C:\Reports\ReplicationSummary.html"
 
@@ -36,7 +55,12 @@
         [switch] $Online,
         [switch] $HideHTML,
         [switch] $PassThru,
-        [switch] $SummaryOnly
+        [switch] $SummaryOnly,
+        [switch] $SkipReplicationTopology,
+        [switch] $SkipReplicationTopologyDiagram,
+        [switch] $SkipSitesSubnets,
+        [switch] $SkipSitesSubnetsDiagram,
+        [ValidateSet('DC', 'Subnet')][string[]] $DiagramSitesSubnetsNodes = @('DC', 'Subnet')
     )
     $Script:Reporting = [ordered] @{}
     $Script:Reporting['Version'] = Get-GitHubVersion -Cmdlet 'Invoke-ADEssentials' -RepositoryOwner 'evotecit' -RepositoryName 'ADEssentials'
@@ -227,159 +251,171 @@
                 }
             }
             if (-not $SummaryOnly) {
-                New-HTMLTab -TabName 'Replication Topology & Details' {
-                    New-HTMLSection -HeaderText 'Replication Topology' {
-                        New-HTMLDiagram -Height 'calc(50vh)' {
-                            New-DiagramEvent -ID 'DT-ReplicationDetails' -ColumnID 0
-                            New-DiagramEvent -ID 'DT-ReplicationMatrix' -ColumnID 0
-                            New-DiagramEvent -ID 'DT-DCPartnerSummary' -ColumnID 0
-                            New-DiagramOptionsPhysics -RepulsionNodeDistance 150 -Solver repulsion
+                if (-not $SkipReplicationTopology) {
+                    New-HTMLTab -TabName 'Replication Topology & Details' {
+                        if (-not $SkipReplicationTopologyDiagram) {
+                            New-HTMLSection -HeaderText 'Replication Topology' {
+                                New-HTMLDiagram -Height 'calc(50vh)' {
+                                    New-DiagramEvent -ID 'DT-ReplicationDetails' -ColumnID 0
+                                    New-DiagramEvent -ID 'DT-ReplicationMatrix' -ColumnID 0
+                                    New-DiagramEvent -ID 'DT-DCPartnerSummary' -ColumnID 0
+                                    New-DiagramOptionsPhysics -RepulsionNodeDistance 150 -Solver repulsion
 
-                            # Add Nodes (Domain Controllers)
-                            foreach ($DCName in $DCs.Keys) {
-                                $DCInfo = $DCs[$DCName]
-                                # $NodeLabel = "$($DCInfo.Label)`n$($DCInfo.IP)" # Add IP to label
-                                $NodeLabel = $DCInfo.Label
-                                $NodeColor = if ($DCInfo.Status) { "#c5e8cd" } else { "#f7bec3" } # Light green or light red
-                                $SiteName = ""
-                                # Add site information if available
-                                foreach ($DCPartner in $DCPartnerSummary) {
-                                    if ($DCPartner.DomainController -eq $DCName -and $DCPartner.Site) {
-                                        $SiteName = $DCPartner.Site
-                                        break
+                                    # Add Nodes (Domain Controllers)
+                                    foreach ($DCName in $DCs.Keys) {
+                                        $DCInfo = $DCs[$DCName]
+                                        # $NodeLabel = "$($DCInfo.Label)`n$($DCInfo.IP)" # Add IP to label
+                                        $NodeLabel = $DCInfo.Label
+                                        $NodeColor = if ($DCInfo.Status) { "#c5e8cd" } else { "#f7bec3" } # Light green or light red
+                                        $SiteName = ""
+                                        # Add site information if available
+                                        foreach ($DCPartner in $DCPartnerSummary) {
+                                            if ($DCPartner.DomainController -eq $DCName -and $DCPartner.Site) {
+                                                $SiteName = $DCPartner.Site
+                                                break
+                                            }
+                                        }
+                                        $NodeTitle = "DC: $($DCInfo.Label)"
+                                        if ($SiteName) {
+                                            $NodeTitle += " (Site: $SiteName)"
+                                        }
+                                        #New-DiagramNode -Id $DCName -Label $NodeLabel -Title $NodeTitle -ColorBackground $NodeColor
+                                        New-DiagramNode -Id $DCName -Label $NodeLabel -ColorBackground $NodeColor -Shape box
                                     }
-                                }
-                                $NodeTitle = "DC: $($DCInfo.Label)"
-                                if ($SiteName) {
-                                    $NodeTitle += " (Site: $SiteName)"
-                                }
-                                #New-DiagramNode -Id $DCName -Label $NodeLabel -Title $NodeTitle -ColorBackground $NodeColor
-                                New-DiagramNode -Id $DCName -Label $NodeLabel -ColorBackground $NodeColor -Shape box
+
+                                    # Track which connections we've already processed to avoid duplicates
+                                    $ProcessedLinks = @{}
+
+                                    # Directly use the Links collection to create edges between DCs
+                                    foreach ($Link in $Links) {
+                                        $FromDC = $Link.From
+                                        $ToDC = $Link.To
+                                        $LinkKey = "$FromDC-$ToDC"
+                                        $ReverseKey = "$ToDC-$FromDC"
+
+                                        # Skip if we've already processed this link
+                                        if ($ProcessedLinks.ContainsKey($LinkKey) -or $ProcessedLinks.ContainsKey($ReverseKey)) {
+                                            continue
+                                        }
+
+                                        # Mark as processed
+                                        $ProcessedLinks[$LinkKey] = $true
+
+                                        # Determine if it's bidirectional
+                                        $Bidirectional = $false
+                                        $ReverseLink = $Links | Where-Object { $_.From -eq $ToDC -and $_.To -eq $FromDC } | Select-Object -First 1
+                                        if ($ReverseLink) {
+                                            $Bidirectional = $true
+                                            # Mark reverse link as processed too
+                                            $ProcessedLinks[$ReverseKey] = $true
+                                        }
+
+                                        # Determine status and color
+                                        $EdgeColor = if ($Link.Status) { 'Green' } else { 'Red' }
+                                        $EdgeDashes = -not $Link.Status # Dashed line for failures
+
+                                        if ($Bidirectional) {
+                                            # Create bidirectional edge
+                                            New-DiagramEdge -From $FromDC -To $ToDC -Color $EdgeColor -ArrowsToEnabled -ArrowsFromEnabled -Dashes $EdgeDashes -Label "Both" -FontAlign middle
+                                        } else {
+                                            # Create directional edge
+                                            New-DiagramEdge -From $ToDC -To $FromDC -Color $EdgeColor -ArrowsToEnabled -Dashes $EdgeDashes -Label "One-way" -FontAlign middle
+                                        }
+                                    }
+                                } -EnableFiltering -EnableFilteringButton
                             }
-
-                            # Track which connections we've already processed to avoid duplicates
-                            $ProcessedLinks = @{}
-
-                            # Directly use the Links collection to create edges between DCs
-                            foreach ($Link in $Links) {
-                                $FromDC = $Link.From
-                                $ToDC = $Link.To
-                                $LinkKey = "$FromDC-$ToDC"
-                                $ReverseKey = "$ToDC-$FromDC"
-
-                                # Skip if we've already processed this link
-                                if ($ProcessedLinks.ContainsKey($LinkKey) -or $ProcessedLinks.ContainsKey($ReverseKey)) {
-                                    continue
-                                }
-
-                                # Mark as processed
-                                $ProcessedLinks[$LinkKey] = $true
-
-                                # Determine if it's bidirectional
-                                $Bidirectional = $false
-                                $ReverseLink = $Links | Where-Object { $_.From -eq $ToDC -and $_.To -eq $FromDC } | Select-Object -First 1
-                                if ($ReverseLink) {
-                                    $Bidirectional = $true
-                                    # Mark reverse link as processed too
-                                    $ProcessedLinks[$ReverseKey] = $true
-                                }
-
-                                # Determine status and color
-                                $EdgeColor = if ($Link.Status) { 'Green' } else { 'Red' }
-                                $EdgeDashes = -not $Link.Status # Dashed line for failures
-
-                                if ($Bidirectional) {
-                                    # Create bidirectional edge
-                                    New-DiagramEdge -From $FromDC -To $ToDC -Color $EdgeColor -ArrowsToEnabled -ArrowsFromEnabled -Dashes $EdgeDashes -Label "Both" -FontAlign middle
-                                } else {
-                                    # Create directional edge
-                                    New-DiagramEdge -From $ToDC -To $FromDC -Color $EdgeColor -ArrowsToEnabled -Dashes $EdgeDashes -Label "One-way" -FontAlign middle
-                                }
-                            }
-                        } -EnableFiltering -EnableFilteringButton
-                    }
-                    New-HTMLSection -HeaderText 'Domain Controller Replication Partners' {
-                        New-HTMLTable -DataTable $DCPartnerSummary -DataTableID 'DT-DCPartnerSummary' -Filtering -ScrollX {
-                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'Healthy' -BackgroundColor LightGreen -FailBackgroundColor Salmon
                         }
-                    }
-
-                    New-HTMLSection -HeaderText 'Replication Matrix' {
-                        New-HTMLPanel {
-                            New-HTMLTable -DataTable $ReplicationMatrix {
-                                New-HTMLTableHeader -Names $MatrixHeaders -Title "Domain Controller Inbound Partners"
-                                foreach ($Header in $MatrixHeaders) {
-                                    New-HTMLTableCondition -Value '✓' -ComparisonType string -Operator eq -BackgroundColor LightGreen -Name $Header
-                                    New-HTMLTableCondition -Value '✗' -ComparisonType string -Operator eq -BackgroundColor Salmon -Name $Header
-                                    New-HTMLTableCondition -Value '-' -ComparisonType string -Operator eq -BackgroundColor LightYellow -Name $Header
-                                }
-                            } -ScrollX -DataTableID 'DT-ReplicationMatrix' -Filtering
-                        }
-                    }
-
-                    New-HTMLSection -HeaderText 'Detailed Replication Status' {
-                        # Add conditional formatting for Status column
-                        New-HTMLTable -DataTable $ReplicationData -DataTableID 'DT-ReplicationDetails' -Filtering -ScrollX {
-                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value $false -BackgroundColor '#f7bec3' -Row
-
-                            New-HTMLTableCondition -Name 'LastReplicationResult' -ComparisonType string -Operator eq -Value "0" -BackgroundColor LightGreen -FailBackgroundColor Salmon
-                            New-HTMLTableCondition -Name 'ConsecutiveReplicationFailures' -ComparisonType string -Operator eq -Value "0" -BackgroundColor LightGreen -FailBackgroundColor Salmon
-
-                            $Properties = @('ScheduledSync', 'SyncOnStartup')
-                            foreach ($Property in $Properties) {
-                                New-HTMLTableCondition -Name $Property -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor Salmon
+                        New-HTMLSection -HeaderText 'Domain Controller Replication Partners' {
+                            New-HTMLTable -DataTable $DCPartnerSummary -DataTableID 'DT-DCPartnerSummary' -Filtering -ScrollX {
+                                New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'Healthy' -BackgroundColor LightGreen -FailBackgroundColor Salmon
                             }
-                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor Salmon -HighlightHeaders 'Status', 'StatusMessage'
-                            New-HTMLTableCondition -Name 'Writable' -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor LightYellow
+                        }
+
+                        New-HTMLSection -HeaderText 'Replication Matrix' {
+                            New-HTMLPanel {
+                                New-HTMLTable -DataTable $ReplicationMatrix {
+                                    New-HTMLTableHeader -Names $MatrixHeaders -Title "Domain Controller Inbound Partners"
+                                    foreach ($Header in $MatrixHeaders) {
+                                        New-HTMLTableCondition -Value '✓' -ComparisonType string -Operator eq -BackgroundColor LightGreen -Name $Header
+                                        New-HTMLTableCondition -Value '✗' -ComparisonType string -Operator eq -BackgroundColor Salmon -Name $Header
+                                        New-HTMLTableCondition -Value '-' -ComparisonType string -Operator eq -BackgroundColor LightYellow -Name $Header
+                                    }
+                                } -ScrollX -DataTableID 'DT-ReplicationMatrix' -Filtering
+                            }
+                        }
+
+                        New-HTMLSection -HeaderText 'Detailed Replication Status' {
+                            # Add conditional formatting for Status column
+                            New-HTMLTable -DataTable $ReplicationData -DataTableID 'DT-ReplicationDetails' -Filtering -ScrollX {
+                                New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value $false -BackgroundColor '#f7bec3' -Row
+
+                                New-HTMLTableCondition -Name 'LastReplicationResult' -ComparisonType string -Operator eq -Value "0" -BackgroundColor LightGreen -FailBackgroundColor Salmon
+                                New-HTMLTableCondition -Name 'ConsecutiveReplicationFailures' -ComparisonType string -Operator eq -Value "0" -BackgroundColor LightGreen -FailBackgroundColor Salmon
+
+                                $Properties = @('ScheduledSync', 'SyncOnStartup')
+                                foreach ($Property in $Properties) {
+                                    New-HTMLTableCondition -Name $Property -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor Salmon
+                                }
+                                New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor Salmon -HighlightHeaders 'Status', 'StatusMessage'
+                                New-HTMLTableCondition -Name 'Writable' -ComparisonType string -Operator eq -Value "True" -BackgroundColor LightGreen -FailBackgroundColor LightYellow
+                            }
                         }
                     }
                 }
-                New-HTMLTab -TabName 'Sites & Subnets' {
-                    New-HTMLSection -HeaderText 'Organization Diagram' {
-                        New-HTMLDiagram -Height 'calc(50vh)' {
-                            New-DiagramEvent -ID 'DT-StandardSites' -ColumnID 0
-                            New-DiagramOptionsPhysics -RepulsionNodeDistance 150 -Solver repulsion
-                            foreach ($Site in $Sites) {
-                                New-DiagramNode -Id $Site.DistinguishedName -Label $Site.Name -Image 'https://cdn-icons-png.flaticon.com/512/1104/1104991.png' -ImageType squareImage
-                                foreach ($Subnet in $Site.Subnets) {
-                                    New-DiagramNode -Id $Subnet -Label $Subnet -Image 'https://cdn-icons-png.flaticon.com/512/1674/1674968.png' -ImageType squareImage
-                                    New-DiagramEdge -From $Subnet -To $Site.DistinguishedName
-                                }
-                                foreach ($DC in $Site.DomainControllers) {
-                                    New-DiagramNode -Id $DC -Label $DC -Image 'https://cdn-icons-png.flaticon.com/512/1383/1383395.png' -ImageType squareImage
-                                    New-DiagramEdge -From $DC -To $Site.DistinguishedName
-                                }
+                if (-not $SkipSitesSubnets) {
+                    New-HTMLTab -TabName 'Sites & Subnets' {
+                        if (-not $SkipSitesSubnetsDiagram) {
+                            New-HTMLSection -HeaderText 'Sites & Subnets Diagram' {
+                                New-HTMLDiagram -Height 'calc(50vh)' {
+                                    New-DiagramEvent -ID 'DT-StandardSites' -ColumnID 0
+                                    New-DiagramOptionsPhysics -RepulsionNodeDistance 150 -Solver repulsion
+                                    foreach ($Site in $Sites) {
+                                        New-DiagramNode -Id $Site.DistinguishedName -Label $Site.Name -Image 'https://cdn-icons-png.flaticon.com/512/1104/1104991.png' -ImageType squareImage
+                                        if ($DiagramSitesSubnetsNodes -contains 'Subnet') {
+                                            foreach ($Subnet in $Site.Subnets) {
+                                                New-DiagramNode -Id $Subnet -Label $Subnet -Image 'https://cdn-icons-png.flaticon.com/512/1674/1674968.png' -ImageType squareImage
+                                                New-DiagramEdge -From $Subnet -To $Site.DistinguishedName
+                                            }
+                                        }
+                                        if ($DiagramSitesSubnetsNodes -contains 'DC') {
+                                            foreach ($DC in $Site.DomainControllers) {
+                                                New-DiagramNode -Id $DC -Label $DC -Image 'https://cdn-icons-png.flaticon.com/512/1383/1383395.png' -ImageType squareImage
+                                                New-DiagramEdge -From $DC -To $Site.DistinguishedName
+                                            }
+                                        }
+                                    }
+                                    # foreach ($R in $CacheReplication.Values) {
+                                    #     if ($R.ConsecutiveReplicationFailures -gt 0) {
+                                    #         $Color = 'CoralRed'
+                                    #     } else {
+                                    #         $Color = 'MediumSeaGreen'
+                                    #     }
+                                    #     New-DiagramEdge -From $R.Server -To $R.ServerPartner -Color $Color -ArrowsToEnabled -ColorOpacity 0.5
+                                    # }
+                                } -EnableFiltering -EnableFilteringButton
                             }
-                            foreach ($R in $CacheReplication.Values) {
-                                if ($R.ConsecutiveReplicationFailures -gt 0) {
-                                    $Color = 'CoralRed'
-                                } else {
-                                    $Color = 'MediumSeaGreen'
-                                }
-                                New-DiagramEdge -From $R.Server -To $R.ServerPartner -Color $Color -ArrowsToEnabled -ColorOpacity 0.5
+                        }
+                        New-HTMLSection -HeaderText 'Sites' {
+                            New-HTMLTable -DataTable $Sites -DataTableID 'DT-Sites' -Filtering -ScrollX {
+                                New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType number -Value 0 -Name SubnetsCount -Operator gt
+                                New-TableCondition -BackgroundColor CoralRed -ComparisonType number -Value 0 -Name SubnetsCount -Operator eq
                             }
-                        } -EnableFiltering -EnableFilteringButton
-                    }
-                    New-HTMLSection -HeaderText 'Sites' {
-                        New-HTMLTable -DataTable $Sites -DataTableID 'DT-Sites' -Filtering -ScrollX {
-                            New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType number -Value 0 -Name SubnetsCount -Operator gt
-                            New-TableCondition -BackgroundColor CoralRed -ComparisonType number -Value 0 -Name SubnetsCount -Operator eq
                         }
-                    }
-                    New-HTMLSection -HeaderText 'Subnets' {
-                        New-HTMLTable -DataTable $Subnets -DataTableID 'DT-Subnets' -Filtering -ScrollX {
-                            New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType string -Value $true -Name SiteStatus -FailBackgroundColor CoralRed
-                            New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType string -Value $false -Name Overlap -FailBackgroundColor CoralRed
+                        New-HTMLSection -HeaderText 'Subnets' {
+                            New-HTMLTable -DataTable $Subnets -DataTableID 'DT-Subnets' -Filtering -ScrollX {
+                                New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType string -Value $true -Name SiteStatus -FailBackgroundColor CoralRed
+                                New-TableCondition -BackgroundColor MediumSeaGreen -ComparisonType string -Value $false -Name Overlap -FailBackgroundColor CoralRed
+                            }
                         }
-                    }
-                    New-HTMLSection -HeaderText 'Site Links' {
-                        New-HTMLTable -DataTable $SiteLinks -DataTableID 'DT-SiteLinks' -Filtering -ScrollX {
+                        New-HTMLSection -HeaderText 'Site Links' {
+                            New-HTMLTable -DataTable $SiteLinks -DataTableID 'DT-SiteLinks' -Filtering -ScrollX {
 
+                            }
                         }
-                    }
-                    New-HTMLSection -HeaderText 'Site Options' {
-                        New-HTMLTable -DataTable $SiteOptions -DataTableID 'DT-SiteOptions' -Filtering -ScrollX {
+                        New-HTMLSection -HeaderText 'Site Options' {
+                            New-HTMLTable -DataTable $SiteOptions -DataTableID 'DT-SiteOptions' -Filtering -ScrollX {
 
+                            }
                         }
                     }
                 }
@@ -426,7 +462,7 @@
                 EmailText -Text "For more details please check the table below:"
 
                 EmailTable -DataTable $ReplicationSummary {
-                    EmailTableCondition -Inline -Name "Fail" -HighlightHeaders 'Fails', 'Total', 'PercentageError' -ComparisonType number -Operator gt 0 -BackGroundColor Salmon -FailBackgroundColor SpringGreen
+                    EmailTableCondition -Inline -Name "Fail" -HighlightHeaders 'Fails', 'Total', 'PercentageError' -ComparisonType number -Operator gt 0 -BackgroundColor Salmon -FailBackgroundColor SpringGreen
                 } -HideFooter
 
                 EmailText -LineBreak

--- a/Public/Show-WinADForestReplicationSummary.ps1
+++ b/Public/Show-WinADForestReplicationSummary.ps1
@@ -68,16 +68,19 @@
     if ($FilePath -eq '') {
         $FilePath = Get-FileName -Extension 'html' -Temporary
     }
-
+    Write-Verbose -Message "Show-WinADForestReplicationSummary - Getting Replication Summary"
     $ReplicationSummary = Get-WinADForestReplicationSummary -IncludeStatisticsVariable Statistics
 
+    Write-Verbose -Message "Show-WinADForestReplicationSummary - Getting SiteLinks"
     $SiteLinks = Get-WinADSiteLinks
+    Write-Verbose -Message "Show-WinADForestReplicationSummary - Getting SiteOptions"
     $SiteOptions = Get-WinADSiteOptions
 
+    Write-Verbose -Message "Show-WinADForestReplicationSummary - Getting Replication Summary"
     if ($SummaryOnly) {
         $ReplicationOutput = Get-WinADForestReplication -Extended
     } else {
-        $ReplicationOutput = Get-WinADForestReplication -Extended -All
+        $ReplicationOutput = Get-WinADForestReplication -Extended -All -SkipReplicationTopology:$SkipReplicationTopology.IsPresent -SkipSitesSubnets:$SkipSitesSubnets.IsPresent
     }
     # Lets build the report using the data from Get-WinADForestReplication
     $ReplicationData = $ReplicationOutput.ReplicationData
@@ -88,6 +91,8 @@
     $MatrixHeaders = $ReplicationOutput.MatrixHeaders
     $Sites = $ReplicationOutput.Sites
     $Subnets = $ReplicationOutput.Subnets
+
+    Write-Verbose -Message "Show-WinADForestReplicationSummary - Generating HTML report"
 
     New-HTML {
         New-HTMLSectionStyle -BorderRadius 0px -HeaderBackGroundColor Grey -RemoveShadow
@@ -462,7 +467,7 @@
                 EmailText -Text "For more details please check the table below:"
 
                 EmailTable -DataTable $ReplicationSummary {
-                    EmailTableCondition -Inline -Name "Fail" -HighlightHeaders 'Fails', 'Total', 'PercentageError' -ComparisonType number -Operator gt 0 -BackgroundColor Salmon -FailBackgroundColor SpringGreen
+                    EmailTableCondition -Inline -Name "Fail" -HighlightHeaders 'Fails', 'Total', 'PercentageError' -ComparisonType number -Operator gt 0 -BackGroundColor Salmon -FailBackgroundColor SpringGreen
                 } -HideFooter
 
                 EmailText -LineBreak


### PR DESCRIPTION
This PR resolves:
- https://github.com/EvotecIT/ADEssentials/issues/54

- Improve `Get-WinADForestSubnet`
  - Added handling for CNF objects
  - Improved error handling for IP address and integer conversions
  - Added better warning messages for malformed subnets
- Improved `Show-WinADForestReplicationSummary`