### PR TITLE
Enhance DHCP Failover Reporting and Validation

### DIFF
--- a/Examples/Example-DHCPFailoverMismatches.ps1
+++ b/Examples/Example-DHCPFailoverMismatches.ps1
@@ -1,0 +1,8 @@
+Import-Module .\ADEssentials.psd1 -Force
+
+# Generate a minimal validation report using TestMode to showcase
+# enhanced failover mismatch detection (primary-only, secondary-only, missing on both)
+$null = Show-WinADDHCPSummary -Minimal -TestMode -Verbose -FilePath "$PSScriptRoot\Reports\DHCPFailoverMismatches.html" -HideHTML
+
+Write-Host "Test report generated: $PSScriptRoot\Reports\DHCPFailoverMismatches.html"
+

--- a/Examples/Example-DHCPSummaryMinimal.ps1
+++ b/Examples/Example-DHCPSummaryMinimal.ps1
@@ -48,8 +48,8 @@ $EmailBody = EmailBody {
 Connect-MgGraph -Scopes 'Mail.Send' -NoWelcome
 
 $EmailSplat = @{
-    From     = 'przemyslaw.klys@evotec.pl'
-    To       = 'przemyslaw.klys@evotec.pl'
+    From     = 'przemyslaw.klys@company.pl'
+    To       = 'przemyslaw.klys@company.pl'
     Body     = $EmailBody
     Priority = if ($CriticalCount -gt 0) { 'High' } else { 'Low' }
     Subject  = if ($CriticalCount -gt 0) { "DHCP Validation: Critical issues found ($CriticalCount)" } else { 'DHCP Validation: OK' }

--- a/Private/Get-TestModeDHCPData.ps1
+++ b/Private/Get-TestModeDHCPData.ps1
@@ -551,6 +551,37 @@
             }
             return $null
         }
+
+        'DhcpServerv4FailoverAll' {
+            # Simulate full failover relationship listing per server
+            switch ($ComputerName) {
+                'dhcp01.domain.com' {
+                    return @(
+                        [PSCustomObject]@{
+                            Name          = 'dhcp01-dhcp02-failover'
+                            PartnerServer = 'dhcp02.domain.com'
+                            Mode          = 'LoadBalance'
+                            State         = 'Normal'
+                            # Scopes on primary list: include 192.168.1.0 and 10.1.0.0; exclude 10.3.0.0 and 10.4.0.0
+                            ScopeId       = @('192.168.1.0','10.1.0.0')
+                        }
+                    )
+                }
+                'dhcp02.domain.com' {
+                    return @(
+                        [PSCustomObject]@{
+                            Name          = 'dhcp01-dhcp02-failover'
+                            PartnerServer = 'dhcp01.domain.com'
+                            Mode          = 'LoadBalance'
+                            State         = 'Normal'
+                            # Scopes on secondary list: include 192.168.1.0 and 10.3.0.0; exclude 10.1.0.0 and 10.4.0.0
+                            ScopeId       = @('192.168.1.0','10.3.0.0')
+                        }
+                    )
+                }
+                default { return @() }
+            }
+        }
         
         'DhcpServerv4Class' {
             if ($ComputerName -eq 'dhcp01.domain.com') {

--- a/Private/Get-WinADDHCPFailoverAnalysis.ps1
+++ b/Private/Get-WinADDHCPFailoverAnalysis.ps1
@@ -1,0 +1,103 @@
+function Get-WinADDHCPFailoverAnalysis {
+    [CmdletBinding()]
+    param(
+        [System.Collections.IDictionary] $DHCPSummary
+    )
+
+    # Prepare containers for analysis results
+    $OnlyOnPrimary   = [System.Collections.Generic.List[Object]]::new()
+    $OnlyOnSecondary = [System.Collections.Generic.List[Object]]::new()
+    $MissingOnBoth   = [System.Collections.Generic.List[Object]]::new()
+
+    if (-not $DHCPSummary.FailoverRelationships -or $DHCPSummary.FailoverRelationships.Count -eq 0) {
+        # Nothing to analyze
+        $DHCPSummary.FailoverAnalysis = [ordered]@{
+            OnlyOnPrimary   = $OnlyOnPrimary
+            OnlyOnSecondary = $OnlyOnSecondary
+            MissingOnBoth   = $MissingOnBoth
+        }
+        return
+    }
+
+    # Group relationships by pair (relationship name + normalized partner tuple)
+    $pairs = @{}
+    foreach ($rel in $DHCPSummary.FailoverRelationships) {
+        $a = $rel.ServerName.ToLower()
+        $b = $rel.PartnerServer.ToLower()
+        $sorted = @($a,$b) | Sort-Object
+        $pairKey = "$($rel.Name.ToLower())|$($sorted -join '↔')"
+        if (-not $pairs.ContainsKey($pairKey)) {
+            $pairs[$pairKey] = [ordered]@{
+                Name = $rel.Name
+                ServerA = $sorted[0]
+                ServerB = $sorted[1]
+                RelA = $null
+                RelB = $null
+            }
+        }
+        if ($rel.ServerName.ToLower() -eq $pairs[$pairKey].ServerA) {
+            $pairs[$pairKey].RelA = $rel
+        } else {
+            $pairs[$pairKey].RelB = $rel
+        }
+    }
+
+    foreach ($pair in $pairs.Values) {
+        $relA = $pair.RelA
+        $relB = $pair.RelB
+
+        # Normalize lists
+        $scopesA = @()
+        $scopesB = @()
+        if ($relA -and $relA.ScopeId) { $scopesA = @($relA.ScopeId) } else { $scopesA = @() }
+        if ($relB -and $relB.ScopeId) { $scopesB = @($relB.ScopeId) } else { $scopesB = @() }
+
+        # Compare differences
+        $diff = Compare-Object -ReferenceObject $scopesA -DifferenceObject $scopesB
+        foreach ($d in $diff) {
+            $scopeId = $d.InputObject
+            if ($d.SideIndicator -eq '<=') {
+                # Present only on ServerA (treat as Primary for the pair)
+                $OnlyOnPrimary.Add([PSCustomObject]@{
+                    Relationship   = $pair.Name
+                    PrimaryServer  = $pair.ServerA
+                    SecondaryServer= $pair.ServerB
+                    ScopeId        = $scopeId
+                    Issue          = 'Present only on primary'
+                })
+            } elseif ($d.SideIndicator -eq '=>') {
+                # Present only on ServerB (treat as Secondary)
+                $OnlyOnSecondary.Add([PSCustomObject]@{
+                    Relationship   = $pair.Name
+                    PrimaryServer  = $pair.ServerA
+                    SecondaryServer= $pair.ServerB
+                    ScopeId        = $scopeId
+                    Issue          = 'Present only on secondary'
+                })
+            }
+        }
+
+        # Missing on both: scopes that exist on either server as DHCP scopes but are not assigned to failover on A nor B
+        $allScopesForPair = @()
+        $allScopesForPair += ($DHCPSummary.Scopes | Where-Object { $_.ServerName -and ($_.ServerName.ToLower() -in @($pair.ServerA, $pair.ServerB)) } | Select-Object -ExpandProperty ScopeId -Unique)
+        $assignedUnion = @($scopesA + $scopesB) | Select-Object -Unique
+        foreach ($s in $allScopesForPair) {
+            if ($assignedUnion -notcontains $s) {
+                $MissingOnBoth.Add([PSCustomObject]@{
+                    Relationship   = $pair.Name
+                    PrimaryServer  = $pair.ServerA
+                    SecondaryServer= $pair.ServerB
+                    ScopeId        = $s
+                    Issue          = 'Missing from both partners'
+                })
+            }
+        }
+    }
+
+    $DHCPSummary.FailoverAnalysis = [ordered]@{
+        OnlyOnPrimary   = $OnlyOnPrimary
+        OnlyOnSecondary = $OnlyOnSecondary
+        MissingOnBoth   = $MissingOnBoth
+    }
+}
+

--- a/Private/Get-WinADDHCPFailoverRelationships.ps1
+++ b/Private/Get-WinADDHCPFailoverRelationships.ps1
@@ -1,0 +1,36 @@
+function Get-WinADDHCPFailoverRelationships {
+    [CmdletBinding()]
+    param(
+        [string] $Computer,
+        [System.Collections.IDictionary] $DHCPSummary,
+        [switch] $TestMode
+    )
+
+    try {
+        $relationships = @()
+        if ($TestMode) {
+            $relationships = Get-TestModeDHCPData -DataType 'DhcpServerv4FailoverAll' -ComputerName $Computer
+        } else {
+            $relationships = Get-DhcpServerv4Failover -ComputerName $Computer -ErrorAction Stop
+        }
+
+        foreach ($rel in $relationships) {
+            if (-not $rel) { continue }
+            # Normalize to a consistent object shape used throughout the report
+            $obj = [PSCustomObject]@{
+                ServerName        = $Computer
+                PrimaryServerName = if ($rel.PSObject.Properties.Name -contains 'PrimaryServerName' -and $rel.PrimaryServerName) { $rel.PrimaryServerName } else { $Computer }
+                PartnerServer     = $rel.PartnerServer
+                Name              = $rel.Name
+                Mode              = $rel.Mode
+                State             = $rel.State
+                ScopeId           = $rel.ScopeId
+                GatheredFrom      = $Computer
+                GatheredDate      = Get-Date
+            }
+            $DHCPSummary.FailoverRelationships.Add($obj)
+        }
+    } catch {
+        Add-DHCPError -Summary $DHCPSummary -ServerName $Computer -Component 'Failover Relationships' -Operation 'Get-DhcpServerv4Failover' -ErrorMessage $_.Exception.Message -Severity 'Warning'
+    }
+}

--- a/Private/New-DHCPIPv4IPv6Tab.ps1
+++ b/Private/New-DHCPIPv4IPv6Tab.ps1
@@ -83,7 +83,7 @@
                             New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 75 -BackgroundColor Orange -HighlightHeaders 'PercentageInUse'
                             New-HTMLTableCondition -Name 'LeaseDurationHours' -ComparisonType number -Operator gt -Value 48 -BackgroundColor Yellow -HighlightHeaders 'LeaseDurationHours'
                             New-HTMLTableCondition -Name 'FailoverPartner' -ComparisonType string -Operator eq -Value '' -BackgroundColor LightYellow -HighlightHeaders 'FailoverPartner'
-                        } -DataStore JavaScript -ScrollX -Title "All IPv4 Scopes" -ExcludeProperty 'DNSSettings'
+                        } -DataStore JavaScript -ScrollX -Title "All IPv4 Scopes" -IncludeProperty 'ServerName','ScopeId','Name','State','LeaseDurationHours','DNSServers','DomainNameOption','DynamicUpdates','UpdateDnsRRForOlderClients','DeleteDnsRROnLeaseExpiry','FailoverPartner','HasFailover','FailoverConfiguration' -ExcludeProperty 'DNSSettings'
                     }
                 } else {
                     New-HTMLPanel -Invisible {

--- a/Private/New-DHCPMinimalAllScopesTab.ps1
+++ b/Private/New-DHCPMinimalAllScopesTab.ps1
@@ -36,7 +36,7 @@
                         'ServerName', 'ScopeId', 'Name', 'State', 'LeaseDurationHours',
                         'DNSServers', 'DomainNameOption', 'DynamicUpdates',
                         'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry',
-                        'FailoverPartner'
+                        'FailoverPartner', 'HasFailover', 'FailoverConfiguration'
                     )
                 }
             }
@@ -60,7 +60,7 @@
                         'ServerName', 'ScopeId', 'Name', 'State', 'LeaseDurationHours',
                         'DNSServers', 'DomainNameOption', 'DynamicUpdates',
                         'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry',
-                        'FailoverPartner', 'Issues'
+                        'FailoverPartner', 'HasFailover', 'FailoverConfiguration', 'Issues'
                     )
                 }
             }

--- a/Private/New-DHCPOverviewTab.ps1
+++ b/Private/New-DHCPOverviewTab.ps1
@@ -180,8 +180,8 @@
                 }
             }
 
-            New-HTMLSection -HeaderText "Address Pool Utilization" -Invisible -Density Compact {
-                New-HTMLInfoCard -Title "Total IP Addresses" -Number $TotalAddresses.ToString("N0") -Subtitle "Pool Capacity" -Icon "🚀" -TitleColor 'DodgerBlue' -NumberColor 'Navy' -ShadowColor 'rgba(30, 144, 255, 0.15)'
+        New-HTMLSection -HeaderText "Address Pool Utilization" -Invisible -Density Compact {
+            New-HTMLInfoCard -Title "Total IP Addresses" -Number $TotalAddresses.ToString("N0") -Subtitle "Pool Capacity" -Icon "🚀" -TitleColor 'DodgerBlue' -NumberColor 'Navy' -ShadowColor 'rgba(30, 144, 255, 0.15)'
 
                 if ($OverallPercentageInUse -gt 80) {
                     New-HTMLInfoCard -Title "Addresses In Use" -Number $AddressesInUse.ToString("N0") -Subtitle "High Utilization" -Icon "🚨" -TitleColor 'Crimson' -NumberColor 'DarkRed' -ShadowColor 'rgba(220, 20, 60, 0.25)' -ShadowIntensity ExtraBold
@@ -202,6 +202,21 @@
                 } else {
                     New-HTMLInfoCard -Title "Overall Utilization" -Number "$OverallPercentageInUse%" -Subtitle "Low Usage" -Icon "🌱" -TitleColor 'LimeGreen' -NumberColor 'DarkGreen' -ShadowColor 'rgba(50, 205, 50, 0.15)'
                 }
+            }
+        }
+
+        # Failover Overview (new) - show critical failover coverage and mismatches
+        if ($DHCPData.FailoverRelationships.Count -ge 0) {
+            New-HTMLSection -HeaderText "Failover Overview" -Invisible -Density Compact {
+                $ScopesWithoutFailover = ($DHCPData.Scopes | Where-Object { $_.State -eq 'Active' -and (-not $_.HasFailover) }).Count
+                $OnlyOnPrimary   = if ($DHCPData.FailoverAnalysis) { $DHCPData.FailoverAnalysis.OnlyOnPrimary.Count } else { 0 }
+                $OnlyOnSecondary = if ($DHCPData.FailoverAnalysis) { $DHCPData.FailoverAnalysis.OnlyOnSecondary.Count } else { 0 }
+                $MissingOnBoth   = if ($DHCPData.FailoverAnalysis) { $DHCPData.FailoverAnalysis.MissingOnBoth.Count } else { 0 }
+
+                New-HTMLInfoCard -Title "Unprotected Scopes" -Number $ScopesWithoutFailover -Subtitle "No Failover" -Icon "🚨" -TitleColor $(if ($ScopesWithoutFailover -gt 0) { 'Orange' } else { 'Green' }) -NumberColor $(if ($ScopesWithoutFailover -gt 0) { 'DarkOrange' } else { 'DarkGreen' })
+                New-HTMLInfoCard -Title "Only on Primary" -Number $OnlyOnPrimary -Subtitle "Mismatch" -Icon "🟠" -TitleColor 'DarkOrange' -NumberColor 'DarkOrange'
+                New-HTMLInfoCard -Title "Only on Secondary" -Number $OnlyOnSecondary -Subtitle "Mismatch" -Icon "🟠" -TitleColor 'DarkOrange' -NumberColor 'DarkOrange'
+                New-HTMLInfoCard -Title "Missing on Both" -Number $MissingOnBoth -Subtitle "Gap" -Icon "⚠️" -TitleColor 'OrangeRed' -NumberColor 'OrangeRed'
             }
         }
 

--- a/Public/Get-WinADDHCPHealthCheck.ps1
+++ b/Public/Get-WinADDHCPHealthCheck.ps1
@@ -185,6 +185,23 @@
     if ($Summary.ValidationResults.Summary.TotalWarningIssues -gt 0) {
         if ($Summary.ValidationResults.WarningIssues.MissingFailover.Count -gt 0) {
             $Recommendations += "⚠️ Configure DHCP failover for high-availability scopes"
+            $Issues += "⚠️ $($Summary.ValidationResults.WarningIssues.MissingFailover.Count) scope(s) missing failover"
+            $HealthScore -= [Math]::Min(10, $Summary.ValidationResults.WarningIssues.MissingFailover.Count)
+        }
+        if ($Summary.ValidationResults.WarningIssues.FailoverOnlyOnPrimary.Count -gt 0) {
+            $Recommendations += "⚠️ Synchronize failover scope lists: present only on primary"
+            $Issues += "⚠️ $($Summary.ValidationResults.WarningIssues.FailoverOnlyOnPrimary.Count) scope(s) only on primary failover list"
+            $HealthScore -= [Math]::Min(10, $Summary.ValidationResults.WarningIssues.FailoverOnlyOnPrimary.Count)
+        }
+        if ($Summary.ValidationResults.WarningIssues.FailoverOnlyOnSecondary.Count -gt 0) {
+            $Recommendations += "⚠️ Synchronize failover scope lists: present only on secondary"
+            $Issues += "⚠️ $($Summary.ValidationResults.WarningIssues.FailoverOnlyOnSecondary.Count) scope(s) only on secondary failover list"
+            $HealthScore -= [Math]::Min(10, $Summary.ValidationResults.WarningIssues.FailoverOnlyOnSecondary.Count)
+        }
+        if ($Summary.ValidationResults.WarningIssues.FailoverMissingOnBoth.Count -gt 0) {
+            $Recommendations += "⚠️ Add scopes to failover on both partners"
+            $Issues += "⚠️ $($Summary.ValidationResults.WarningIssues.FailoverMissingOnBoth.Count) scope(s) missing on both failover lists"
+            $HealthScore -= [Math]::Min(15, $Summary.ValidationResults.WarningIssues.FailoverMissingOnBoth.Count)
         }
         if ($Summary.ValidationResults.WarningIssues.ExtendedLeaseDuration.Count -gt 0) {
             $Recommendations += "⚠️ Review extended lease durations for potential optimization"

--- a/Public/Show-WinADDHCPSummary.ps1
+++ b/Public/Show-WinADDHCPSummary.ps1
@@ -114,6 +114,10 @@
         [switch] $PassThru,
         [switch] $TestMode,
         [switch] $Minimal,
+        # Validation policy toggles
+        [switch] $ConsiderMissingFailoverCritical,
+        [switch] $ConsiderDNSConfigCritical,
+        [switch] $IncludeServerAvailabilityIssues,
         [string[]] $IncludeTabs = @('Overview', 'IPv4/IPv6', 'Utilization', 'ValidationIssues', 'Infrastructure', 'Options&Classes', 'Failover', 'NetworkSegmentation', 'Performance', 'SecurityCompliance'),
         [string[]] $ExcludeTabs = @(),
         [switch] $ShowTimingStatistics
@@ -158,6 +162,9 @@
 
     if ($TestMode) { $GetWinADDHCPSummarySplat.TestMode = $TestMode }
     if ($Minimal) { $GetWinADDHCPSummarySplat.Minimal = $Minimal }
+    if ($ConsiderMissingFailoverCritical) { $GetWinADDHCPSummarySplat.ConsiderMissingFailoverCritical = $true }
+    if ($ConsiderDNSConfigCritical) { $GetWinADDHCPSummarySplat.ConsiderDNSConfigCritical = $true }
+    if ($IncludeServerAvailabilityIssues) { $GetWinADDHCPSummarySplat.IncludeServerAvailabilityIssues = $true }
 
     Write-Verbose "Show-WinADDHCPSummary - Gathering DHCP data from Get-WinADDHCPSummary"
     $DHCPData = Get-WinADDHCPSummary @GetWinADDHCPSummarySplat


### PR DESCRIPTION
- Added detailed failover analysis cards to the DHCP Failover tab, including counts of scopes only on primary, only on secondary, and missing on both.
- Implemented pair-wise analysis views for failover relationships, allowing for a comprehensive comparison of scope assignments between primary and secondary servers.
- Updated the DHCP Overview tab to include a new Failover Overview section summarizing critical failover coverage and mismatches.
- Enhanced validation issues reporting to include specific warnings for scopes with failover configuration issues, including those only present on primary or secondary servers.
- Improved health check recommendations to address missing failover configurations and mismatches.
- Refined the summary script to collect and analyze failover relationships upfront for better performance and accuracy in reporting.