### PR TITLE
Fix Get-WinDNSRecords child-domain forest lookups

### DIFF
--- a/Private/Get-WinDnsZoneSearchBase.ps1
+++ b/Private/Get-WinDnsZoneSearchBase.ps1
@@ -1,0 +1,29 @@
+function Get-WinDnsZoneSearchBase {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject] $Zone,
+
+        [Parameter(Mandatory)]
+        [psobject] $RootDSE
+    )
+
+    if ($Zone.DistinguishedName) {
+        return $Zone.DistinguishedName
+    }
+
+    if ($Zone.ReplicationScope -eq 'Domain') {
+        return "DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=DomainDnsZones,$($RootDSE.defaultNamingContext)"
+    }
+
+    if ($Zone.ReplicationScope -eq 'Forest') {
+        $ForestNamingContext = if ($RootDSE.rootDomainNamingContext) {
+            $RootDSE.rootDomainNamingContext
+        } else {
+            $RootDSE.defaultNamingContext
+        }
+        return "DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=ForestDnsZones,$ForestNamingContext"
+    }
+
+    return $null
+}

--- a/Public/Get-WinADDnsIPAddresses.ps1
+++ b/Public/Get-WinADDnsIPAddresses.ps1
@@ -86,13 +86,15 @@
             $TempObjects = @(
                 if ($Zone.ReplicationScope -eq 'Domain') {
                     try {
-                        Get-ADObject -Server $ADServer -Filter $Filter -SearchBase ("DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=DomainDnsZones," + $oRootDSE.defaultNamingContext) -Properties CanonicalName, whenChanged, whenCreated, DistinguishedName, ProtectedFromAccidentalDeletion, dNSTombstoned
+                        $SearchBase = Get-WinDnsZoneSearchBase -Zone $Zone -RootDSE $oRootDSE
+                        Get-ADObject -Server $ADServer -Filter $Filter -SearchBase $SearchBase -Properties CanonicalName, whenChanged, whenCreated, DistinguishedName, ProtectedFromAccidentalDeletion, dNSTombstoned
                     } catch {
                         Write-Warning -Message "Get-WinADDnsIPAddresses - Error getting AD records for DomainDnsZones zone: $($Zone.ZoneName). Error: $($_.Exception.Message)"
                     }
                 } elseif ($Zone.ReplicationScope -eq 'Forest') {
                     try {
-                        Get-ADObject -Server $ADServer -Filter $Filter -SearchBase ("DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=ForestDnsZones," + $oRootDSE.defaultNamingContext) -Properties CanonicalName, whenChanged, whenCreated, DistinguishedName, ProtectedFromAccidentalDeletion, dNSTombstoned
+                        $SearchBase = Get-WinDnsZoneSearchBase -Zone $Zone -RootDSE $oRootDSE
+                        Get-ADObject -Server $ADServer -Filter $Filter -SearchBase $SearchBase -Properties CanonicalName, whenChanged, whenCreated, DistinguishedName, ProtectedFromAccidentalDeletion, dNSTombstoned
                     } catch {
                         Write-Warning -Message "Get-WinADDnsIPAddresses - Error getting AD records for ForestDnsZones zone: $($Zone.ZoneName). Error: $($_.Exception.Message)"
                     }

--- a/Public/Get-WinADDnsRecords.ps1
+++ b/Public/Get-WinADDnsRecords.ps1
@@ -76,27 +76,36 @@
     foreach ($Zone in $ZonesToProcess) {
         Write-Verbose -Message "Get-WinDNSRecords - Processing zone for DNS records: $($Zone.ZoneName)"
         $DNSRecordsPerZone[$Zone.ZoneName] = Get-DnsServerResourceRecord -ComputerName $ADServer -ZoneName $Zone.ZoneName -RRType A
+        $ADRecordsPerZone[$Zone.ZoneName] = [ordered] @{}
         $ADRecordsPerZoneByDns[$Zone.ZoneName] = [ordered] @{}
         foreach ($Record in  $DNSRecordsPerZone[$Zone.ZoneName]) {
             if (-not $ADRecordsPerZoneByDns[$Zone.ZoneName][$Record.HostName]) {
                 $ADRecordsPerZoneByDns[$Zone.ZoneName][$Record.HostName] = [System.Collections.Generic.List[Object]]::new()
             }
             $ADRecordsPerZoneByDns[$Zone.ZoneName][$Record.HostName].Add($Record)
+            if (-not $ADRecordsPerZone[$Zone.ZoneName][$Record.HostName]) {
+                $ADRecordsPerZone[$Zone.ZoneName][$Record.HostName] = [PSCustomObject] @{
+                    Name          = $Record.HostName
+                    dNSTombstoned = $false
+                    whenCreated   = $null
+                    whenChanged   = $null
+                }
+            }
         }
     }
     if ($IncludeDetails) {
         #$Filter = { (Name -notlike "@" -and Name -notlike "_*" -and ObjectClass -eq 'dnsNode' -and Name -ne 'ForestDnsZone' -and Name -ne 'DomainDnsZone' ) }
         $Filter = "(Name -notlike '@' -and Name -notlike '_*' -and ObjectClass -eq 'dnsNode' -and Name -ne 'ForestDnsZone' -and Name -ne 'DomainDnsZone' )"
         foreach ($Zone in $ZonesToProcess) {
-            $ADRecordsPerZone[$Zone.ZoneName] = [ordered]@{}
             Write-Verbose -Message "Get-WinDNSRecords - Processing zone for AD records: $($Zone.ZoneName)"
             $TempObjects = @(
                 if ($Zone.ReplicationScope -eq 'Domain') {
                     try {
+                        $SearchBase = Get-WinDnsZoneSearchBase -Zone $Zone -RootDSE $oRootDSE
                         $getADObjectSplat = @{
                             Server     = $ADServer
                             Filter     = $Filter
-                            SearchBase = ("DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=DomainDnsZones," + $oRootDSE.defaultNamingContext)
+                            SearchBase = $SearchBase
                             Properties = 'CanonicalName', 'whenChanged', 'whenCreated', 'DistinguishedName', 'ProtectedFromAccidentalDeletion', 'dNSTombstoned', 'nTSecurityDescriptor'
                         }
                         Get-ADObject @getADObjectSplat
@@ -105,10 +114,11 @@
                     }
                 } elseif ($Zone.ReplicationScope -eq 'Forest') {
                     try {
+                        $SearchBase = Get-WinDnsZoneSearchBase -Zone $Zone -RootDSE $oRootDSE
                         $getADObjectSplat = @{
                             Server     = $ADServer
                             Filter     = $Filter
-                            SearchBase = ("DC=$($Zone.ZoneName),CN=MicrosoftDNS,DC=ForestDnsZones," + $oRootDSE.defaultNamingContext)
+                            SearchBase = $SearchBase
                             Properties = 'CanonicalName', 'whenChanged', 'whenCreated', 'DistinguishedName', 'ProtectedFromAccidentalDeletion', 'dNSTombstoned', 'nTSecurityDescriptor'
                         }
                         Get-ADObject @getADObjectSplat

--- a/Tests/Get-WinADDnsRecords.Tests.ps1
+++ b/Tests/Get-WinADDnsRecords.Tests.ps1
@@ -1,0 +1,212 @@
+function global:Get-ADRootDSE {
+    param()
+
+    & $global:GetADRootDSEImpl @PSBoundParameters
+}
+
+function global:Get-DnsServerZone {
+    param(
+        [string] $ComputerName
+    )
+
+    & $global:GetDnsServerZoneImpl @PSBoundParameters
+}
+
+function global:Get-DnsServerResourceRecord {
+    param(
+        [string] $ComputerName,
+        [string] $ZoneName,
+        [string] $RRType
+    )
+
+    & $global:GetDnsServerResourceRecordImpl @PSBoundParameters
+}
+
+function global:Get-ADObject {
+    param(
+        [string] $Server,
+        [string] $Filter,
+        [string] $SearchBase,
+        [object[]] $Properties
+    )
+
+    & $global:GetADObjectImpl @PSBoundParameters
+}
+
+Describe 'DNS record enumeration' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force
+    }
+
+    BeforeEach {
+        $global:lastSearchBase = $null
+
+        $global:GetADRootDSEImpl = {
+            [PSCustomObject] @{
+                dnsHostName             = 'dc01.child.parent.local'
+                defaultNamingContext    = 'DC=child,DC=parent,DC=local'
+                rootDomainNamingContext = 'DC=parent,DC=local'
+            }
+        }
+
+        $global:GetDnsServerZoneImpl = {
+            @(
+                [PSCustomObject] @{
+                    ZoneName            = 'child.parent.local'
+                    ZoneType            = 'Primary'
+                    IsDsIntegrated      = $true
+                    IsReverseLookupZone = $false
+                    ReplicationScope    = 'Forest'
+                    DistinguishedName   = $null
+                }
+            )
+        }
+
+        $global:GetDnsServerResourceRecordImpl = {
+            @(
+                [PSCustomObject] @{
+                    HostName   = 'server1'
+                    TimeStamp  = $null
+                    RecordData = [PSCustomObject] @{
+                        IPv4Address = '10.0.0.10'
+                    }
+                }
+            )
+        }
+
+        $global:GetADObjectImpl = {
+            throw 'Get-ADObject should be mocked per test.'
+        }
+    }
+
+    It 'returns DNS-backed entries without IncludeDetails' {
+        $result = Get-WinDNSRecords
+
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 1
+        $result[0].HostName | Should -Be 'server1'
+        $result[0].Zone | Should -Be 'child.parent.local'
+        $result[0].RecordIP | Should -Contain '10.0.0.10'
+    }
+
+    It 'uses the forest root naming context for child-domain forest zones when details are requested' {
+        $global:GetADObjectImpl = {
+            param(
+                [string] $Server,
+                [string] $Filter,
+                [string] $SearchBase,
+                [object[]] $Properties
+            )
+
+            $global:lastSearchBase = $SearchBase
+
+            @(
+                [PSCustomObject] @{
+                    Name                          = 'server1'
+                    whenCreated                   = [datetime]'2025-01-01'
+                    whenChanged                   = [datetime]'2025-01-02'
+                    DistinguishedName             = 'DC=server1,DC=child.parent.local,CN=MicrosoftDNS,DC=ForestDnsZones,DC=parent,DC=local'
+                    ProtectedFromAccidentalDeletion = $false
+                    dNSTombstoned                 = $false
+                    nTSecurityDescriptor          = [PSCustomObject] @{
+                        Owner = 'CONTOSO\Domain Admins'
+                    }
+                }
+            )
+        }
+
+        $result = Get-WinDNSRecords -IncludeDetails
+
+        $global:lastSearchBase | Should -Be 'DC=child.parent.local,CN=MicrosoftDNS,DC=ForestDnsZones,DC=parent,DC=local'
+        $result | Should -Not -BeNullOrEmpty
+        $result[0].WhenCreated | Should -Be ([datetime]'2025-01-01')
+    }
+
+    It 'keeps returning DNS results when AD enrichment for details fails' {
+        $global:GetADObjectImpl = {
+            throw 'Directory object not found.'
+        }
+
+        $result = Get-WinDNSRecords -IncludeDetails
+
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 1
+        $result[0].HostName | Should -Be 'server1'
+        $result[0].RecordIP | Should -Contain '10.0.0.10'
+    }
+}
+
+Describe 'DNS IP enumeration' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force
+    }
+
+    BeforeEach {
+        $global:lastIpSearchBase = $null
+
+        $global:GetADRootDSEImpl = {
+            [PSCustomObject] @{
+                dnsHostName             = 'dc01.child.parent.local'
+                defaultNamingContext    = 'DC=child,DC=parent,DC=local'
+                rootDomainNamingContext = 'DC=parent,DC=local'
+            }
+        }
+
+        $global:GetDnsServerZoneImpl = {
+            @(
+                [PSCustomObject] @{
+                    ZoneName            = 'child.parent.local'
+                    ZoneType            = 'Primary'
+                    IsDsIntegrated      = $true
+                    IsReverseLookupZone = $false
+                    ReplicationScope    = 'Forest'
+                    DistinguishedName   = $null
+                }
+            )
+        }
+
+        $global:GetDnsServerResourceRecordImpl = {
+            @(
+                [PSCustomObject] @{
+                    HostName   = 'server1'
+                    TimeStamp  = $null
+                    RecordData = [PSCustomObject] @{
+                        IPv4Address = '10.0.0.10'
+                    }
+                }
+            )
+        }
+
+        $global:GetADObjectImpl = {
+            throw 'Get-ADObject should be mocked per test.'
+        }
+    }
+
+    It 'uses the forest root naming context for child-domain forest zones in IP lookups' {
+        $global:GetADObjectImpl = {
+            param(
+                [string] $Server,
+                [string] $Filter,
+                [string] $SearchBase,
+                [object[]] $Properties
+            )
+
+            $global:lastIpSearchBase = $SearchBase
+
+            @(
+                [PSCustomObject] @{
+                    Name          = 'server1'
+                    whenCreated   = [datetime]'2025-01-01'
+                    whenChanged   = [datetime]'2025-01-02'
+                    dNSTombstoned = $false
+                }
+            )
+        }
+
+        $result = Get-WinADDnsIPAddresses -IncludeDetails
+
+        $global:lastIpSearchBase | Should -Be 'DC=child.parent.local,CN=MicrosoftDNS,DC=ForestDnsZones,DC=parent,DC=local'
+        $result | Should -Not -BeNullOrEmpty
+        $result[0].IPAddress | Should -Be '10.0.0.10'
+    }
+}


### PR DESCRIPTION
## Summary
- fix forest DNS partition lookups in child domains by resolving the search base from the zone or forest root naming context instead of the child domain naming context
- make `Get-WinDNSRecords` return DNS-backed results even when `-IncludeDetails` is not used or AD enrichment fails
- add focused regression tests covering child-domain forest lookups and DNS-only fallback behavior

Fixes #77

## Verification
- `pwsh -NoProfile -Command "Import-Module .\ADEssentials.psd1 -Force; Invoke-Pester -Path .\Tests\Get-WinADDnsRecords.Tests.ps1 -Output Detailed"`
