### PR TITLE
Improve DHCP validation and report presentation

### DIFF
--- a/Private/ConvertTo-DHCPOptionIssueRecord.ps1
+++ b/Private/ConvertTo-DHCPOptionIssueRecord.ps1
@@ -1,0 +1,62 @@
+function ConvertTo-DHCPOptionIssueRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object] $Issue
+    )
+
+    if ($null -eq $Issue) {
+        return $null
+    }
+
+    if ($Issue -isnot [string]) {
+        $text = if ($Issue.PSObject.Properties['Issue']) { [string] $Issue.Issue } else { [string] $Issue }
+        $serverName = if ($Issue.PSObject.Properties['ServerName']) { [string] $Issue.ServerName } else { $null }
+        $scopeId = if ($Issue.PSObject.Properties['ScopeId']) { [string] $Issue.ScopeId } else { $null }
+        $category = if ($Issue.PSObject.Properties['Category']) { [string] $Issue.Category } else { 'Other' }
+        $recommendation = if ($Issue.PSObject.Properties['Recommendation']) { [string] $Issue.Recommendation } else { 'Review the DHCP option configuration and align it with the approved standard.' }
+        return [PSCustomObject]@{
+            Category       = $category
+            ServerName     = $serverName
+            ScopeId        = $scopeId
+            Details        = $text
+            Recommendation = $recommendation
+        }
+    }
+
+    $text = [string] $Issue
+    $category = 'Other'
+    $serverName = $null
+    $scopeId = $null
+    $recommendation = 'Review the DHCP option configuration and align it with the approved standard.'
+
+    if ($text -match '^Public DNS servers configured in scope (?<scope>.+?) on (?<server>.+)$') {
+        $category = 'Public DNS'
+        $scopeId = $Matches.scope
+        $serverName = $Matches.server
+        $recommendation = 'Replace public DNS servers with approved internal DNS servers or document the exception.'
+    } elseif ($text -match '^Very long lease time \((?<hours>\d+) hours\) in scope (?<scope>.+?) on (?<server>.+)$') {
+        $category = 'Lease Time'
+        $scopeId = $Matches.scope
+        $serverName = $Matches.server
+        $recommendation = 'Reduce the lease duration to 168 hours or less unless the longer value is explicitly approved.'
+    } elseif ($text -match '^Empty domain name in scope (?<scope>.+?) on (?<server>.+)$') {
+        $category = 'Domain Name'
+        $scopeId = $Matches.scope
+        $serverName = $Matches.server
+        $recommendation = 'Configure DHCP option 15 with the expected DNS domain name.'
+    } elseif ($text -match '^Invalid lease time format in scope (?<scope>.+?) on (?<server>.+)$') {
+        $category = 'Lease Time Format'
+        $scopeId = $Matches.scope
+        $serverName = $Matches.server
+        $recommendation = 'Verify DHCP option 51 uses a valid numeric value expressed in seconds.'
+    }
+
+    [PSCustomObject]@{
+        Category       = $category
+        ServerName     = $serverName
+        ScopeId        = $scopeId
+        Details        = $text
+        Recommendation = $recommendation
+    }
+}

--- a/Private/ConvertTo-DHCPOptionIssueRecord.ps1
+++ b/Private/ConvertTo-DHCPOptionIssueRecord.ps1
@@ -9,12 +9,21 @@ function ConvertTo-DHCPOptionIssueRecord {
         return $null
     }
 
+    if ($Issue -is [string] -and [string]::IsNullOrWhiteSpace($Issue)) {
+        return $null
+    }
+
     if ($Issue -isnot [string]) {
         $text = if ($Issue.PSObject.Properties['Issue']) { [string] $Issue.Issue } else { [string] $Issue }
         $serverName = if ($Issue.PSObject.Properties['ServerName']) { [string] $Issue.ServerName } else { $null }
         $scopeId = if ($Issue.PSObject.Properties['ScopeId']) { [string] $Issue.ScopeId } else { $null }
         $category = if ($Issue.PSObject.Properties['Category']) { [string] $Issue.Category } else { 'Other' }
         $recommendation = if ($Issue.PSObject.Properties['Recommendation']) { [string] $Issue.Recommendation } else { 'Review the DHCP option configuration and align it with the approved standard.' }
+
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            return $null
+        }
+
         return [PSCustomObject]@{
             Category       = $category
             ServerName     = $serverName

--- a/Private/Get-WinADDHCPScopeValidation.ps1
+++ b/Private/Get-WinADDHCPScopeValidation.ps1
@@ -17,6 +17,13 @@
         }
     }
 
+    # PTR registration should stay enabled
+    if ($ScopeObject.DisableDnsPtrRRUpdate -eq $true) {
+        $ScopeObject.Issues.Add("DisableDnsPtrRRUpdate is enabled")
+        $ScopeObject.Issues.Add("PTR registration disabled")
+        $ScopeObject.HasIssues = $true
+    }
+
     # Check for dynamic DNS updates with public DNS servers
     if ($ScopeObject.DNSSettings -and $ScopeObject.DNSSettings.DynamicUpdates -ne 'Never') {
         if ($ScopeObject.DNSServers) {

--- a/Private/Get-WinADDHCPValidationResults.ps1
+++ b/Private/Get-WinADDHCPValidationResults.ps1
@@ -133,12 +133,11 @@
         if ($MissingDomainName     -and $MissingDomainName.Count     -gt 0) { [void] $dnsAgg.AddRange($MissingDomainName) }
 
         # Deduplicate by (ServerName|ScopeId)
-        $seen = @{}
+        $seen = [System.Collections.Generic.HashSet[string]]::new()
         $dnsUnique = New-Object 'System.Collections.Generic.List[object]'
         foreach ($item in $dnsAgg) {
             $id = "$($item.ServerName)|$($item.ScopeId)"
-            if (-not $seen.ContainsKey($id)) {
-                $seen[$id] = $true
+            if ($seen.Add($id)) {
                 [void] $dnsUnique.Add($item)
             }
         }

--- a/Private/Get-WinADDHCPValidationResults.ps1
+++ b/Private/Get-WinADDHCPValidationResults.ps1
@@ -53,7 +53,7 @@
             if ($Issue -like "*exceeds 48 hours*") {
                 if ($ExtendedLeaseDuration -notcontains $Scope) { $ExtendedLeaseDuration.Add($Scope) }
             }
-            if ($Issue -like "*UpdateDnsRRForOlderClients*" -or $Issue -like "*DeleteDnsRROnLeaseExpiry*") {
+            if ($Issue -like "*UpdateDnsRRForOlderClients*" -or $Issue -like "*DeleteDnsRROnLeaseExpiry*" -or $Issue -like "*DisableDnsPtrRRUpdate*" -or $Issue -like "*PTR registration disabled*") {
                 if ($DNSRecordManagement -notcontains $Scope) { $DNSRecordManagement.Add($Scope) }
             }
             if ($Issue -like "*Domain name option*") {

--- a/Private/New-DHCPFailoverTab.ps1
+++ b/Private/New-DHCPFailoverTab.ps1
@@ -164,7 +164,7 @@
                 if ($rel.ServerName.ToLower() -eq $Pairs[$key].ServerA) { $Pairs[$key].RelA = $rel } else { $Pairs[$key].RelB = $rel }
             }
 
-            foreach ($pair in $Pairs.Values) {
+            $pairRows = foreach ($pair in $Pairs.Values) {
                 $relA = $pair.RelA
                 $relB = $pair.RelB
                 $scopesA = if ($relA -and $relA.ScopeId) { @($relA.ScopeId) } else { @() }
@@ -194,35 +194,49 @@
                 $commonScopes = @($scopesOnA | Where-Object { $scopesOnB -contains $_ })
                 $allScopes = @($scopesA + $scopesB + $commonScopes) | Select-Object -Unique
 
-                $rows = foreach ($s in $allScopes) {
+                foreach ($s in $allScopes) {
                     $onA = $scopesA -contains $s
                     $onB = $scopesB -contains $s
                     $statusBase = if ($onA -and $onB) { 'On both partners' } elseif ($onA) { "Missing on $($pair.ServerB)" } elseif ($onB) { "Missing on $($pair.ServerA)" } else { 'Missing on both' }
                     $status = $statusBase + $(if (-not $verified -and $statusBase -ne 'On both partners') { ' (Unverified)' } else { '' })
-                    $failoverConfig = switch ($status) {
+                    $failoverConfig = switch ($statusBase) {
                         { $_ -like 'Missing on *' } { 'missing on one partner' }
                         'Missing on both' { 'missing on both' }
                         default { 'configured' }
                     }
                     [PSCustomObject]@{
                         Relationship          = $pair.Name
+                        Pair                  = "$($pair.ServerA) ↔ $($pair.ServerB)"
                         PartnerA              = $pair.ServerA
                         PartnerB              = $pair.ServerB
                         ScopeId               = $s
                         OnPartnerA            = $onA
                         OnPartnerB            = $onB
+                        VerifiedFromBothSides = $verified
                         Status                = $status
                         FailoverConfiguration = $failoverConfig
                     }
                 }
+            }
 
-                New-HTMLSection -HeaderText "$($pair.Name) — $($pair.ServerA) ↔ $($pair.ServerB)" {
-                    New-HTMLTable -DataTable $rows -Filtering {
-                        # Critical
-                        New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator like -Value 'Missing on *' -BackgroundColor Salmon
-                        New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'Missing on both' -BackgroundColor Salmon
-                    } -DataStore JavaScript -ScrollX -Title "Scope Assignment Comparison"
+            if (@($pairRows).Count -gt 0) {
+                New-HTMLSection -Invisible {
+                    New-HTMLPanel {
+                        New-HTMLText -Text "Detailed scope comparison across all failover pairs. Use filtering on Relationship, Pair, or Status to narrow the view." -FontSize 12pt -Color DarkSlateGray
+                    } -Width '100%'
                 }
+                New-HTMLSection -Invisible {
+                    New-HTMLPanel {
+                        New-HTMLTable -DataTable $pairRows -Filtering {
+                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'On both partners' -BackgroundColor LightGreen
+                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator like -Value 'Missing on *' -BackgroundColor LightYellow
+                            New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'Missing on both' -BackgroundColor Salmon -Color White
+                            New-HTMLTableCondition -Name 'VerifiedFromBothSides' -ComparisonType bool -Operator eq -Value $false -BackgroundColor Lavender -HighlightHeaders 'VerifiedFromBothSides'
+                        } -DataStore JavaScript -ScrollX -Title 'Scope Assignment Comparison by Relationship Pair'
+                    } -Width '100%'
+                }
+            } else {
+                New-HTMLText -Text "No failover pair comparison data is available." -Color Gray -FontSize 12pt
             }
         }
 
@@ -262,7 +276,7 @@
                             New-HTMLListItem -Text "Provides active-active configuration"
                             New-HTMLListItem -Text "Best for redundancy and load distribution"
                         }
-                    } -Width '48%'
+                    } -Width '100%'
 
                     New-HTMLPanel {
                         New-HTMLText -Text "Hot Standby Mode" -FontSize 14pt -FontWeight bold -Color DarkBlue
@@ -272,7 +286,7 @@
                             New-HTMLListItem -Text "Standby server activates only on primary failure"
                             New-HTMLListItem -Text "Best for specific server preference scenarios"
                         }
-                    } -Width '48%'
+                    } -Width '100%'
                 }
             }
         }

--- a/Private/New-DHCPMinimalAllScopesTab.ps1
+++ b/Private/New-DHCPMinimalAllScopesTab.ps1
@@ -35,7 +35,7 @@
                     } -ScrollX -IncludeProperty @(
                         'ServerName', 'ScopeId', 'Name', 'State', 'LeaseDurationHours',
                         'DNSServers', 'DomainNameOption', 'DynamicUpdates',
-                        'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry',
+                        'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry', 'DisableDnsPtrRRUpdate',
                         'FailoverPartner', 'HasFailover', 'FailoverConfiguration'
                     )
                 }
@@ -56,10 +56,11 @@
                         New-HTMLTableCondition -Name 'DNSServers' -ComparisonType string -Operator contains -Value '1.1' -BackgroundColor Red -Color White
                         New-HTMLTableCondition -Name 'UpdateDnsRRForOlderClients' -ComparisonType bool -Operator eq -Value $false -BackgroundColor Yellow
                         New-HTMLTableCondition -Name 'DeleteDnsRROnLeaseExpiry' -ComparisonType bool -Operator eq -Value $false -BackgroundColor Yellow
+                        New-HTMLTableCondition -Name 'DisableDnsPtrRRUpdate' -ComparisonType bool -Operator eq -Value $true -BackgroundColor Orange
                     } -ScrollX -IncludeProperty @(
                         'ServerName', 'ScopeId', 'Name', 'State', 'LeaseDurationHours',
                         'DNSServers', 'DomainNameOption', 'DynamicUpdates',
-                        'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry',
+                        'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry', 'DisableDnsPtrRRUpdate',
                         'FailoverPartner', 'HasFailover', 'FailoverConfiguration', 'Issues'
                     )
                 }

--- a/Private/New-DHCPMinimalValidationTab.ps1
+++ b/Private/New-DHCPMinimalValidationTab.ps1
@@ -106,11 +106,12 @@
                             New-HTMLTable -DataTable $DNSRecordManagement {
                                 New-HTMLTableCondition -Name 'UpdateDnsRRForOlderClients' -ComparisonType bool -Operator eq -Value $false -BackgroundColor Yellow
                                 New-HTMLTableCondition -Name 'DeleteDnsRROnLeaseExpiry' -ComparisonType bool -Operator eq -Value $false -BackgroundColor Yellow
+                                New-HTMLTableCondition -Name 'DisableDnsPtrRRUpdate' -ComparisonType bool -Operator eq -Value $true -BackgroundColor Orange -Color Black
                             } -ScrollX -IncludeProperty @(
-                                'ServerName', 'ScopeId', 'Name', 'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry', 'DynamicUpdates'
+                                'ServerName', 'ScopeId', 'Name', 'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry', 'DisableDnsPtrRRUpdate', 'DynamicUpdates'
                             ) -Filtering
                             New-HTMLText -Text "Recommendation:" -FontSize 12px -FontWeight bold -Color Blue
-                            New-HTMLText -Text "Enable 'Update DNS RR for Older Clients' and 'Delete DNS RR on Lease Expiry'." -FontSize 11px -Color Blue
+                            New-HTMLText -Text "Enable 'Update DNS RR for Older Clients', enable 'Delete DNS RR on Lease Expiry', and keep 'Disable DNS PTR RR Update' set to FALSE." -FontSize 11px -Color Blue
                         }
                 }
             }

--- a/Private/New-DHCPOptionsClassesTab.ps1
+++ b/Private/New-DHCPOptionsClassesTab.ps1
@@ -46,11 +46,32 @@
 
                                 # Configuration Issues
                                 if ($Analysis.OptionIssues.Count -gt 0) {
+                                    $IssueDetails = foreach ($Issue in $Analysis.OptionIssues) {
+                                        ConvertTo-DHCPOptionIssueRecord -Issue $Issue
+                                    }
+                                    $IssueSummary = $IssueDetails | Group-Object -Property Category | Sort-Object Count -Descending | ForEach-Object {
+                                        $sample = $_.Group | Select-Object -First 1
+                                        [PSCustomObject]@{
+                                            Category       = $_.Name
+                                            IssueCount     = $_.Count
+                                            AffectedScopes = (@($_.Group.ScopeId | Where-Object { $_ } | Sort-Object -Unique)).Count
+                                            AffectedServers= (@($_.Group.ServerName | Where-Object { $_ } | Sort-Object -Unique)).Count
+                                            Recommendation = $sample.Recommendation
+                                        }
+                                    }
+
                                     New-HTMLSection -HeaderText "⚠️ Configuration Issues Found" -CanCollapse {
                                         New-HTMLPanel {
-                                            foreach ($Issue in $Analysis.OptionIssues) {
-                                                New-HTMLText -Text "⚠️ $Issue" -Color Orange -FontSize 14px
-                                            }
+                                            New-HTMLText -Text "The same issues are grouped by category first, then listed in a detailed table." -Color DarkOrange -FontSize 12pt -FontWeight bold
+                                            New-HTMLTable -DataTable $IssueSummary -Filtering {
+                                                New-HTMLTableCondition -Name 'IssueCount' -ComparisonType number -Operator gt -Value 0 -BackgroundColor LightYellow -HighlightHeaders 'IssueCount'
+                                            } -DataStore JavaScript -ScrollX -Title 'Issue Summary by Category'
+
+                                            New-HTMLTable -DataTable $IssueDetails -Filtering {
+                                                New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Public DNS' -BackgroundColor LightYellow
+                                                New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Lease Time' -BackgroundColor Moccasin
+                                                New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Domain Name' -BackgroundColor Lavender
+                                            } -DataStore JavaScript -ScrollX -Title 'Issue Details'
                                         }
                                     }
                                 }

--- a/Private/New-DHCPOptionsTab.ps1
+++ b/Private/New-DHCPOptionsTab.ps1
@@ -42,21 +42,32 @@
 
                         # Configuration Issues
                         if ($Analysis.OptionIssues.Count -gt 0) {
+                            $IssueDetails = foreach ($Issue in $Analysis.OptionIssues) {
+                                ConvertTo-DHCPOptionIssueRecord -Issue $Issue
+                            }
+                            $IssueSummary = $IssueDetails | Group-Object -Property Category | Sort-Object Count -Descending | ForEach-Object {
+                                $sample = $_.Group | Select-Object -First 1
+                                [PSCustomObject]@{
+                                    Category       = $_.Name
+                                    IssueCount     = $_.Count
+                                    AffectedScopes = (@($_.Group.ScopeId | Where-Object { $_ } | Sort-Object -Unique)).Count
+                                    AffectedServers= (@($_.Group.ServerName | Where-Object { $_ } | Sort-Object -Unique)).Count
+                                    Recommendation = $sample.Recommendation
+                                }
+                            }
+
                             New-HTMLSection -HeaderText "⚠️ Configuration Issues Found" -CanCollapse {
                                 New-HTMLPanel {
-                                    foreach ($Issue in $Analysis.OptionIssues) {
-                                        New-HTMLContainer {
-                                            if ($Issue -is [string]) {
-                                                # Handle string format (test mode)
-                                                New-HTMLText -Text "⚠️ $Issue" -Color Orange -FontSize 14px -FontWeight bold
-                                            } else {
-                                                # Handle object format (production)
-                                                New-HTMLText -Text "⚠️ $($Issue.Issue)" -Color Orange -FontSize 14px -FontWeight bold
-                                                New-HTMLText -Text "Servers affected: $($Issue.ServersAffected -join ', ')" -Color DarkOrange -FontSize 12px
-                                                New-HTMLText -Text "Recommendation: $($Issue.Recommendation)" -Color DarkGray -FontSize 12px -FontStyle italic
-                                            }
-                                        }
-                                    }
+                                    New-HTMLText -Text "The same issues are now grouped by category first, with detailed scope-level records below." -Color DarkOrange -FontSize 12pt -FontWeight bold
+                                    New-HTMLTable -DataTable $IssueSummary -Filtering {
+                                        New-HTMLTableCondition -Name 'IssueCount' -ComparisonType number -Operator gt -Value 0 -BackgroundColor LightYellow -HighlightHeaders 'IssueCount'
+                                    } -DataStore JavaScript -ScrollX -Title 'Issue Summary by Category'
+
+                                    New-HTMLTable -DataTable $IssueDetails -Filtering {
+                                        New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Public DNS' -BackgroundColor LightYellow
+                                        New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Lease Time' -BackgroundColor Moccasin
+                                        New-HTMLTableCondition -Name 'Category' -ComparisonType string -Operator eq -Value 'Domain Name' -BackgroundColor Lavender
+                                    } -DataStore JavaScript -ScrollX -Title 'Issue Details'
                                 }
                             }
                         }

--- a/Private/New-DHCPUtilizationTab.ps1
+++ b/Private/New-DHCPUtilizationTab.ps1
@@ -20,6 +20,20 @@
     )
 
     New-HTMLTab -TabName 'Utilization' {
+        $OnlineServerPerformance = @($DHCPData.ServerPerformanceAnalysis | Where-Object { $_.Status -eq 'Online' } | Sort-Object UtilizationPercent -Descending)
+        $TopUtilizedScopes = @($DHCPData.Scopes | Where-Object { $_.State -eq 'Active' } | Sort-Object PercentageInUse -Descending | Select-Object -First 10)
+        $TopServerPerformance = @($OnlineServerPerformance | Select-Object -First 10)
+        $CriticalUtilizationCount = @($DHCPData.ValidationResults.UtilizationIssues.HighUtilization).Count
+        $ModerateUtilizationCount = @($DHCPData.ValidationResults.UtilizationIssues.ModerateUtilization).Count
+        $OverallUtilization = [Math]::Round([double]$DHCPData.Statistics.OverallPercentageInUse, 2)
+        $OverallUtilizationColor = if ($OverallUtilization -gt 90) {
+            'Crimson'
+        } elseif ($OverallUtilization -gt 75) {
+            'DarkOrange'
+        } else {
+            'DodgerBlue'
+        }
+
         # Overall Utilization Summary
         New-HTMLSection -HeaderText "📊 Overall DHCP Utilization Summary" {
             New-HTMLPanel -Invisible {
@@ -28,58 +42,53 @@
                 } else {
                     New-HTMLText -Text "Utilization is based on DHCP scope statistics, which include inactive reservations." -FontSize 11pt -Color DarkGray
                 }
-                # Create utilization gauges
-                New-HTMLSection -Density Compact -Invisible {
-                    New-HTMLPanel {
-                        #New-HTMLText -Text "Overall IP Utilization" -FontSize 14pt -FontWeight bold -Alignment center
-                        New-HTMLChart {
-                            New-ChartRadial -Name "Used" -Value $DHCPData.Statistics.OverallPercentageInUse
-                            New-ChartRadialOptions -CircleType SemiCircleGauge
-                        } -Title "Overall IP Utilization"
-                    }
 
-                    New-HTMLPanel {
-                        New-HTMLText -Text "Address Distribution" -FontSize 14pt -FontWeight bold -Alignment center
-                        New-HTMLChart {
-                            New-ChartDonut -Name "In Use" -Value $DHCPData.Statistics.AddressesInUse -Color '#FF6347'
-                            New-ChartDonut -Name "Available" -Value $DHCPData.Statistics.AddressesFree -Color '#00FF00'
-                        }
-                    }
-
-
-                    if (($DHCPData.ServerPerformanceAnalysis | Where-Object { $_.Status -eq 'Online' }).Count -gt 0) {
-                        New-HTMLPanel -Invisible {
-                            New-HTMLChart -Title "Server Utilization Comparison" {
-                                New-ChartBarOptions -Type bar -Distributed
-                                foreach ($Server in ($DHCPData.ServerPerformanceAnalysis | Where-Object { $_.Status -eq 'Online' })) {
-                                    New-ChartBar -Name $Server.ServerName -Value $Server.UtilizationPercent
-                                }
-                            }
-                        }
-                    }
-                    New-HTMLSection -Invisible {
-                        New-HTMLPanel {
-                            New-HTMLText -Text "Capacity Metrics" -FontSize 14pt -FontWeight bold -Alignment center
-                            $CapacityMetrics = [PSCustomObject]@{
-                                'Total Addresses' = "{0:N0}" -f $DHCPData.Statistics.TotalAddresses
-                                'In Use'          = "{0:N0}" -f $DHCPData.Statistics.AddressesInUse
-                                'Available'       = "{0:N0}" -f $DHCPData.Statistics.AddressesFree
-                                'Critical Scopes' = ($DHCPData.ValidationResults.UtilizationIssues.HighUtilization.Count)
-                                'Warning Scopes'  = ($DHCPData.ValidationResults.UtilizationIssues.ModerateUtilization.Count)
-                            }
-                            New-HTMLTable -DataTable $CapacityMetrics -HideFooter -DisableSearch -DisablePaging -DisableOrdering
-                        }
-                    }
+                New-HTMLSection -Invisible -Density Compact {
+                    New-HTMLInfoCard -Title "Overall Utilization" -Number "$OverallUtilization%" -Subtitle "Across all active scopes" -Icon "📊" -TitleColor $OverallUtilizationColor -NumberColor $OverallUtilizationColor
+                    New-HTMLInfoCard -Title "Addresses In Use" -Number ("{0:N0}" -f $DHCPData.Statistics.AddressesInUse) -Subtitle "Currently assigned" -Icon "🔴" -TitleColor 'Crimson' -NumberColor 'DarkRed'
+                    New-HTMLInfoCard -Title "Addresses Available" -Number ("{0:N0}" -f $DHCPData.Statistics.AddressesFree) -Subtitle "Remaining capacity" -Icon "🟢" -TitleColor 'LimeGreen' -NumberColor 'DarkGreen'
+                    New-HTMLInfoCard -Title "Critical Scopes" -Number $CriticalUtilizationCount -Subtitle ">90% utilization" -Icon "🚨" -TitleColor $(if ($CriticalUtilizationCount -gt 0) { 'Crimson' } else { 'LimeGreen' }) -NumberColor $(if ($CriticalUtilizationCount -gt 0) { 'DarkRed' } else { 'DarkGreen' })
+                    New-HTMLInfoCard -Title "Warning Scopes" -Number $ModerateUtilizationCount -Subtitle "75-90% utilization" -Icon "⚠️" -TitleColor $(if ($ModerateUtilizationCount -gt 0) { 'DarkOrange' } else { 'LimeGreen' }) -NumberColor $(if ($ModerateUtilizationCount -gt 0) { 'DarkOrange' } else { 'DarkGreen' })
                 }
+
+                $CapacityMetrics = [PSCustomObject]@{
+                    'Total Addresses' = "{0:N0}" -f $DHCPData.Statistics.TotalAddresses
+                    'In Use'          = "{0:N0}" -f $DHCPData.Statistics.AddressesInUse
+                    'Available'       = "{0:N0}" -f $DHCPData.Statistics.AddressesFree
+                    'Critical Scopes' = $CriticalUtilizationCount
+                    'Warning Scopes'  = $ModerateUtilizationCount
+                }
+                New-HTMLTable -DataTable $CapacityMetrics -HideFooter -DisableSearch -DisablePaging -DisableOrdering -Buttons @() -Title 'Capacity Metrics'
             }
         }
 
         # Utilization by Server
         if ($DHCPData.ServerPerformanceAnalysis.Count -gt 0) {
             New-HTMLSection -HeaderText "🖥️ Server Utilization Analysis" -Wrap wrap {
-                # Server utilization chart
-
                 New-HTMLPanel -Invisible {
+                    if ($TopServerPerformance.Count -gt 0) {
+                        $serverRanking = for ($index = 0; $index -lt $TopServerPerformance.Count; $index++) {
+                            [PSCustomObject]@{
+                                Rank               = $index + 1
+                                ServerName         = $TopServerPerformance[$index].ServerName
+                                UtilizationPercent = [Math]::Round([double]$TopServerPerformance[$index].UtilizationPercent, 2)
+                                ActiveScopes       = $TopServerPerformance[$index].ActiveScopes
+                                ScopesWithIssues   = $TopServerPerformance[$index].ScopesWithIssues
+                                PerformanceRating  = $TopServerPerformance[$index].PerformanceRating
+                                CapacityStatus     = $TopServerPerformance[$index].CapacityStatus
+                            }
+                        }
+
+                        New-HTMLText -Text "Top online servers by utilization, shown as a ranking table to keep the layout readable and avoid chart overflow." -FontSize 11pt -Color DarkSlateGray
+                        New-HTMLTable -DataTable $serverRanking -HideFooter -DisableSearch -DisablePaging -DisableOrdering -Buttons @() -Title 'Top 10 Server Utilization' {
+                            New-HTMLTableCondition -Name 'UtilizationPercent' -ComparisonType number -Operator gt -Value 90 -BackgroundColor Red -Color White -HighlightHeaders 'UtilizationPercent', 'CapacityStatus'
+                            New-HTMLTableCondition -Name 'UtilizationPercent' -ComparisonType number -Operator gt -Value 75 -BackgroundColor Orange -HighlightHeaders 'UtilizationPercent'
+                            New-HTMLTableCondition -Name 'UtilizationPercent' -ComparisonType number -Operator gt -Value 50 -BackgroundColor Yellow -HighlightHeaders 'UtilizationPercent'
+                            New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Critical' -BackgroundColor Red -Color White
+                            New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Warning' -BackgroundColor Orange
+                        }
+                    }
+
                     New-HTMLTable -DataTable $DHCPData.ServerPerformanceAnalysis -Filtering {
                         New-HTMLTableCondition -Name 'Status' -ComparisonType string -Operator eq -Value 'Online' -BackgroundColor LightGreen -FailBackgroundColor Salmon
                         New-HTMLTableCondition -Name 'UtilizationPercent' -ComparisonType number -Operator gt -Value 90 -BackgroundColor Red -Color White -HighlightHeaders 'UtilizationPercent'
@@ -87,7 +96,7 @@
                         New-HTMLTableCondition -Name 'UtilizationPercent' -ComparisonType number -Operator gt -Value 50 -BackgroundColor Yellow -HighlightHeaders 'UtilizationPercent'
                         New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Critical' -BackgroundColor Red -Color White
                         New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Warning' -BackgroundColor Orange
-                    } -DataStore JavaScript -Title "Server Capacity and Performance Metrics"
+                    } -DataStore JavaScript -ScrollX -Title "Server Capacity and Performance Metrics"
                 }
             }
         }
@@ -95,18 +104,29 @@
         # Scope Utilization Details
         New-HTMLSection -HeaderText "📈 Scope Utilization Analysis" -Wrap wrap {
             New-HTMLPanel -Invisible {
-                # Top 10 utilized scopes chart
-                $TopUtilizedScopes = $DHCPData.Scopes | Where-Object { $_.State -eq 'Active' } | Sort-Object PercentageInUse -Descending | Select-Object -First 10
+                # Top 10 utilized scopes table
                 if ($TopUtilizedScopes.Count -gt 0) {
-                    New-HTMLChart -Title "Top 10 Most Utilized Scopes" {
-                        New-ChartBarOptions -Type bar -Distributed
-                        foreach ($Scope in $TopUtilizedScopes) {
-                            $Color = if ($Scope.PercentageInUse -gt 90) { '#FF0000' }
-                            elseif ($Scope.PercentageInUse -gt 75) { '#FFA500' }
-                            else { '#00FF00' }
-                            New-ChartBar -Name "$($Scope.Name) ($($Scope.ScopeId))" -Value $Scope.PercentageInUse -Color $Color
+                    $scopeRanking = for ($index = 0; $index -lt $TopUtilizedScopes.Count; $index++) {
+                        [PSCustomObject]@{
+                            Rank               = $index + 1
+                            ServerName         = $TopUtilizedScopes[$index].ServerName
+                            ScopeId            = [string]$TopUtilizedScopes[$index].ScopeId
+                            Name               = $TopUtilizedScopes[$index].Name
+                            PercentageInUse    = [Math]::Round([double]$TopUtilizedScopes[$index].PercentageInUse, 2)
+                            AddressesInUse     = $TopUtilizedScopes[$index].AddressesInUse
+                            AddressesFree      = $TopUtilizedScopes[$index].AddressesFree
+                            CapacityStatus     = if ($TopUtilizedScopes[$index].PercentageInUse -gt 90) { 'Critical' } elseif ($TopUtilizedScopes[$index].PercentageInUse -gt 75) { 'Warning' } else { 'Healthy' }
                         }
-                    } -Height 400
+                    }
+
+                    New-HTMLText -Text "Top 10 most utilized scopes, shown as a compact ranking table instead of a chart to keep the layout stable." -FontSize 11pt -Color DarkSlateGray
+                    New-HTMLTable -DataTable $scopeRanking -HideFooter -DisableSearch -DisablePaging -DisableOrdering -Title 'Top 10 Most Utilized Scopes' -Buttons @() {
+                        New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 90 -BackgroundColor Salmon -HighlightHeaders 'PercentageInUse', 'CapacityStatus'
+                        New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 75 -BackgroundColor LightYellow -HighlightHeaders 'PercentageInUse'
+                        New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Critical' -BackgroundColor Red -Color White
+                        New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Warning' -BackgroundColor Orange
+                        New-HTMLTableCondition -Name 'CapacityStatus' -ComparisonType string -Operator eq -Value 'Healthy' -BackgroundColor LightGreen
+                    }
                 }
             }
             # High utilization scopes
@@ -116,7 +136,7 @@
                     New-HTMLTable -DataTable $DHCPData.ValidationResults.UtilizationIssues.HighUtilization -Filtering {
                         New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 95 -BackgroundColor Red -Color White -HighlightHeaders 'PercentageInUse'
                         New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 90 -BackgroundColor Salmon -HighlightHeaders 'PercentageInUse'
-                    } -DataStore JavaScript
+                    } -DataStore JavaScript -ScrollX
                 }
             }
 
@@ -127,7 +147,7 @@
                     New-HTMLTable -DataTable $DHCPData.ValidationResults.UtilizationIssues.ModerateUtilization -Filtering {
                         New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 85 -BackgroundColor Orange -HighlightHeaders 'PercentageInUse'
                         New-HTMLTableCondition -Name 'PercentageInUse' -ComparisonType number -Operator gt -Value 75 -BackgroundColor Yellow -HighlightHeaders 'PercentageInUse'
-                    } -DataStore JavaScript
+                    } -DataStore JavaScript -ScrollX
                 }
             }
 

--- a/Private/New-DHCPValidationIssuesTab.ps1
+++ b/Private/New-DHCPValidationIssuesTab.ps1
@@ -145,8 +145,14 @@
                 # DNS Record Management Issues
                 if ($DHCPData.ValidationResults.WarningIssues.DNSRecordManagement.Count -gt 0) {
                     New-HTMLSection -HeaderText "DNS Record Management Issues" -CanCollapse {
-                        # Title moved to section header
-                        New-HTMLTable -DataTable $DHCPData.ValidationResults.WarningIssues.DNSRecordManagement -Filtering -DataStore JavaScript -ScrollX
+                        New-HTMLText -Text "Scopes with DNS record management problems:" -FontSize 14pt -FontWeight bold -Color '#cc8800'
+                        New-HTMLTable -DataTable $DHCPData.ValidationResults.WarningIssues.DNSRecordManagement -Filtering -DataStore JavaScript -ScrollX {
+                            New-HTMLTableCondition -Name 'UpdateDnsRRForOlderClients' -ComparisonType bool -Operator eq -Value $false -BackgroundColor LightYellow
+                            New-HTMLTableCondition -Name 'DeleteDnsRROnLeaseExpiry' -ComparisonType bool -Operator eq -Value $false -BackgroundColor LightYellow
+                            New-HTMLTableCondition -Name 'DisableDnsPtrRRUpdate' -ComparisonType bool -Operator eq -Value $true -BackgroundColor Orange
+                        } -IncludeProperty @(
+                            'ServerName', 'ScopeId', 'Name', 'UpdateDnsRRForOlderClients', 'DeleteDnsRROnLeaseExpiry', 'DisableDnsPtrRRUpdate', 'DynamicUpdates'
+                        )
                     }
                 }
             }

--- a/Tests/DHCP.Failover.Tests.ps1
+++ b/Tests/DHCP.Failover.Tests.ps1
@@ -45,6 +45,18 @@ Describe 'DHCP DNS record management validation (TestMode)' {
     }
 }
 
+Describe 'DHCP option issue parsing' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force
+    }
+
+    It 'Returns null for empty or whitespace issue text' {
+        InModuleScope ADEssentials {
+            ConvertTo-DHCPOptionIssueRecord -Issue '   ' | Should -BeNullOrEmpty
+        }
+    }
+}
+
 Describe 'DHCP Server Prefix Filters (TestMode)' {
     BeforeAll {
         Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force

--- a/Tests/DHCP.Failover.Tests.ps1
+++ b/Tests/DHCP.Failover.Tests.ps1
@@ -30,6 +30,21 @@ Describe 'DHCP Failover Analysis (TestMode)' {
     }
 }
 
+Describe 'DHCP DNS record management validation (TestMode)' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force
+    }
+
+    It 'Flags scopes when PTR registration updates are disabled' {
+        $s = Get-WinADDHCPSummary -TestMode -Minimal
+
+        $ptrIssue = $s.ValidationResults.WarningIssues.DNSRecordManagement | Where-Object { [string] $_.ScopeId -eq '10.1.0.0' } | Select-Object -First 1
+        $ptrIssue | Should -Not -BeNullOrEmpty
+        $ptrIssue.DisableDnsPtrRRUpdate | Should -BeTrue
+        $ptrIssue.Issues | Should -Contain 'PTR registration disabled'
+    }
+}
+
 Describe 'DHCP Server Prefix Filters (TestMode)' {
     BeforeAll {
         Import-Module "$PSScriptRoot/../ADEssentials.psm1" -Force

--- a/Website/README.md
+++ b/Website/README.md
@@ -1,0 +1,19 @@
+# ADEssentials Website Content
+
+This folder contains curated source content that the Evotec website imports for the ADEssentials project page.
+
+## Layout
+
+- `content/project-docs/` contains short project documentation pages shown under /projects/adessentials/docs/.
+- `content/examples/` contains curated website examples shown under /projects/adessentials/examples/.
+- API artifacts are not enabled from this folder yet. Add `WebsiteArtifacts/apidocs` and wire it in the website catalog only when external help/API metadata is generated and reviewed.
+
+## Editing Rules
+
+- Keep this folder intentional and small.
+- Do not mirror raw `Examples/`, `Example/`, or generated output folders into the public website.
+- Add only examples that have a clear explanation, a small code sample, and a link back to the original source file.
+- Keep links rooted at /projects/adessentials/ so the same content works on localhost, evotec.xyz, and evotec.pl.
+
+The website pipeline prefers this `Website/content/...` layout over legacy root-level content folders.
+

--- a/Website/content/examples/_index.md
+++ b/Website/content/examples/_index.md
@@ -4,7 +4,7 @@ description: "Curated examples for Active Directory and infrastructure diagnosti
 layout: docs
 ---
 
-These examples are maintained with the ADEssentials repository and selected for the website because they show real operational checks.
+These ADEssentials examples focus on targeted Active Directory checks that are useful before moving into a larger reporting workflow.
 
 ## Featured examples
 

--- a/Website/content/examples/_index.md
+++ b/Website/content/examples/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ADEssentials Examples"
+description: "Curated examples for Active Directory and infrastructure diagnostics with ADEssentials."
+layout: docs
+---
+
+These examples are maintained with the ADEssentials repository and selected for the website because they show real operational checks.
+
+## Featured examples
+
+<div class="ev-example-card-grid">
+  <a class="ev-example-card" href="./verify-ldap-connectivity-and-certificates/">
+    <span class="ev-example-card__eyebrow">Connectivity</span>
+    <h3>Verify LDAP connectivity and certificates</h3>
+    <p>Check LDAP endpoints and certificate-backed communication before deeper troubleshooting.</p>
+  </a>
+  <a class="ev-example-card" href="./check-active-directory-backup-age/">
+    <span class="ev-example-card__eyebrow">Recovery readiness</span>
+    <h3>Check Active Directory backup age</h3>
+    <p>Review forest or domain backup state before change windows or remediation work.</p>
+  </a>
+</div>

--- a/Website/content/examples/check-active-directory-backup-age.md
+++ b/Website/content/examples/check-active-directory-backup-age.md
@@ -24,7 +24,7 @@ $LastBackup = Get-WinADLastBackup
 $LastBackup | Format-Table -AutoSize
 
 # Check selected domains
-$LastBackup = Get-WinADLastBackup -Domain 'ad.evotec.pl', 'ad.evotec.xyz'
+$LastBackup = Get-WinADLastBackup -Domain 'corp.example.com', 'child.corp.example.com'
 $LastBackup | Format-Table -AutoSize
 ```
 

--- a/Website/content/examples/check-active-directory-backup-age.md
+++ b/Website/content/examples/check-active-directory-backup-age.md
@@ -1,0 +1,39 @@
+---
+title: "Check Active Directory backup age"
+description: "Use ADEssentials to review the last known Active Directory backup state across a forest or selected domains."
+layout: docs
+---
+
+This example is useful when you need a quick recovery-readiness check before broader Active Directory troubleshooting or change work.
+
+It comes from the source example at `Examples/Example.06-CheckLastBackup.ps1`.
+
+## When to use this pattern
+
+- You need to confirm whether Active Directory backups are recent enough.
+- You want a forest-wide check before planning changes.
+- You need a narrower check for one or more selected domains.
+
+## Example
+
+```powershell
+Import-Module .\ADEssentials.psd1 -Force
+
+# Check the whole forest
+$LastBackup = Get-WinADLastBackup
+$LastBackup | Format-Table -AutoSize
+
+# Check selected domains
+$LastBackup = Get-WinADLastBackup -Domain 'ad.evotec.pl', 'ad.evotec.xyz'
+$LastBackup | Format-Table -AutoSize
+```
+
+## What this demonstrates
+
+- checking recovery readiness before deeper work
+- running both broad and targeted domain checks
+- producing a compact table that can be shared with the directory team
+
+## Source
+
+- [Example.06-CheckLastBackup.ps1](https://github.com/EvotecIT/ADEssentials/blob/master/Examples/Example.06-CheckLastBackup.ps1)

--- a/Website/content/examples/verify-ldap-connectivity-and-certificates.md
+++ b/Website/content/examples/verify-ldap-connectivity-and-certificates.md
@@ -1,0 +1,35 @@
+---
+title: "Verify LDAP connectivity and certificates"
+description: "Test LDAP endpoints and certificate validation from a PowerShell-based AD health workflow."
+layout: docs
+---
+
+This example is useful when you need a quick LDAP verification pass before deeper Active Directory troubleshooting.
+
+It comes from the source example at `Examples/Example.06-TestLDAPPorts.ps1`.
+
+## When to use this pattern
+
+- You need to confirm LDAP connectivity to domain controllers.
+- You want to validate certificate-backed LDAP communication.
+- You are checking whether a directory issue is network, certificate, or service related.
+
+## Example
+
+```powershell
+Import-Module .\ADEssentials.psd1 -Force
+
+Test-LDAP -IncludeDomainControllers 'ad1.ad.evotec.xyz' -Identity "krbtgt" -Verbose | Format-List *
+Test-LDAP -ComputerName 'ad.evotec.xyz' -VerifyCertificate -Verbose | Format-Table
+Test-LDAP -VerifyCertificate -Verbose -IncludeDomains 'ad.evotec.pl' | Format-Table
+```
+
+## What this demonstrates
+
+- testing specific domain controllers directly
+- validating LDAP over certificate-backed channels
+- comparing narrow and broad validation runs from the same command family
+
+## Source
+
+- [Example.06-TestLDAPPorts.ps1](https://github.com/EvotecIT/ADEssentials/blob/master/Examples/Example.06-TestLDAPPorts.ps1)

--- a/Website/content/examples/verify-ldap-connectivity-and-certificates.md
+++ b/Website/content/examples/verify-ldap-connectivity-and-certificates.md
@@ -19,9 +19,9 @@ It comes from the source example at `Examples/Example.06-TestLDAPPorts.ps1`.
 ```powershell
 Import-Module .\ADEssentials.psd1 -Force
 
-Test-LDAP -IncludeDomainControllers 'ad1.ad.evotec.xyz' -Identity "krbtgt" -Verbose | Format-List *
-Test-LDAP -ComputerName 'ad.evotec.xyz' -VerifyCertificate -Verbose | Format-Table
-Test-LDAP -VerifyCertificate -Verbose -IncludeDomains 'ad.evotec.pl' | Format-Table
+Test-LDAP -IncludeDomainControllers 'dc01.corp.example.com' -Identity "krbtgt" -Verbose | Format-List *
+Test-LDAP -ComputerName 'corp.example.com' -VerifyCertificate -Verbose | Format-Table
+Test-LDAP -VerifyCertificate -Verbose -IncludeDomains 'corp.example.com' | Format-Table
 ```
 
 ## What this demonstrates

--- a/Website/content/project-docs/docs/_index.md
+++ b/Website/content/project-docs/docs/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ADEssentials Docs"
+description: "Curated documentation workspace for ADEssentials."
+layout: docs
+---
+
+ADEssentials collects practical Active Directory helper functions for diagnostics, cleanup, and operational checks.
+
+## Start here
+
+- [Installation](./install/)
+- [Project overview](./overview/)
+- [Back to project overview](/projects/adessentials/)

--- a/Website/content/project-docs/docs/install.md
+++ b/Website/content/project-docs/docs/install.md
@@ -4,7 +4,7 @@ description: "Install ADEssentials from the package source used by this project.
 layout: docs
 ---
 
-Use this page when you need the shortest setup path before trying the curated examples.
+Install ADEssentials before trying the curated Active Directory examples.
 
 ## PowerShell Gallery
 

--- a/Website/content/project-docs/docs/install.md
+++ b/Website/content/project-docs/docs/install.md
@@ -1,0 +1,18 @@
+---
+title: "Install ADEssentials"
+description: "Install ADEssentials from the package source used by this project."
+layout: docs
+---
+
+Use this page when you need the shortest setup path before trying the curated examples.
+
+## PowerShell Gallery
+
+```powershell
+Install-Module ADEssentials -Scope CurrentUser
+```
+
+## Next steps
+
+- Review the [project overview](../overview/)
+- Browse the [curated examples](/projects/adessentials/examples/)

--- a/Website/content/project-docs/docs/overview.md
+++ b/Website/content/project-docs/docs/overview.md
@@ -1,0 +1,22 @@
+---
+title: "ADEssentials overview"
+description: "ADEssentials collects practical Active Directory helper functions for diagnostics, cleanup, and operational checks."
+layout: docs
+---
+
+Use ADEssentials when Active Directory work needs focused checks rather than a full reporting framework. It is useful for targeted health, connectivity, and recovery-readiness tasks.
+
+## Typical use
+
+- LDAP and domain controller connectivity checks
+- Active Directory backup and recovery readiness
+- small helper commands used by larger Evotec automation modules
+
+## Website content contract
+
+The public examples for this project are curated under Website/content/examples in the source repository. Raw repository examples are not mirrored automatically because older project folders often contain experiments, generated output, or environment-specific scripts.
+
+## Related project pages
+
+- [Project overview](/projects/adessentials/)
+- [Examples](/projects/adessentials/examples/)

--- a/Website/content/project-docs/docs/overview.md
+++ b/Website/content/project-docs/docs/overview.md
@@ -12,10 +12,6 @@ Use ADEssentials when Active Directory work needs focused checks rather than a f
 - Active Directory backup and recovery readiness
 - small helper commands used by larger Evotec automation modules
 
-## Website content contract
-
-The public examples for this project are curated under Website/content/examples in the source repository. Raw repository examples are not mirrored automatically because older project folders often contain experiments, generated output, or environment-specific scripts.
-
 ## Related project pages
 
 - [Project overview](/projects/adessentials/)

--- a/Website/content/project-docs/docs/toc.yml
+++ b/Website/content/project-docs/docs/toc.yml
@@ -1,0 +1,6 @@
+- title: Docs Home
+  href: ./
+- title: Install
+  href: install/
+- title: Overview
+  href: overview/


### PR DESCRIPTION
## Summary
- add PTR registration validation for DisableDnsPtrRRUpdate and classify it under DNS record management issues
- simplify DHCP failover, options, and utilization presentation to avoid side-by-side overflow and noisy charts
- add parsing and table-based summaries for DHCP option issues and extend DHCP TestMode coverage

## Testing
- Invoke-Pester -Path .\\Tests\\DHCP.Failover.Tests.ps1 -Output Detailed

## Notes
- checked the staged diff for accidental 'abb' occurrences and found none in tracked changes
