### PR TITLE
Fix CircularIndirect false positives and add CircularPath

### DIFF
--- a/Private/ConvertTo-WinADCircularPath.ps1
+++ b/Private/ConvertTo-WinADCircularPath.ps1
@@ -1,0 +1,33 @@
+﻿function ConvertTo-WinADCircularPath {
+    <#
+    .SYNOPSIS
+    Converts a chain of distinguished names into a readable circular membership path.
+
+    .DESCRIPTION
+    Converts a chain of distinguished names into a readable circular membership path such as "GroupA -> GroupB -> GroupA".
+    Names are resolved from the provided object cache. If an object is not cached its distinguished name is used as is.
+
+    .PARAMETER DistinguishedName
+    Chain of distinguished names describing the circular membership, in traversal order.
+
+    .PARAMETER Cache
+    Dictionary of already resolved AD objects, keyed by distinguished name.
+
+    .EXAMPLE
+    ConvertTo-WinADCircularPath -DistinguishedName @('CN=GroupA,DC=ad,DC=local', 'CN=GroupB,DC=ad,DC=local', 'CN=GroupA,DC=ad,DC=local') -Cache $Cache
+    Returns 'GroupA -> GroupB -> GroupA' when both groups are present in the cache.
+    #>
+    [CmdletBinding()]
+    param(
+        [string[]] $DistinguishedName,
+        [System.Collections.IDictionary] $Cache
+    )
+    $Names = foreach ($DN in $DistinguishedName) {
+        if ($Cache -and $Cache[$DN] -and $Cache[$DN].Name) {
+            $Cache[$DN].Name
+        } else {
+            $DN
+        }
+    }
+    $Names -join ' -> '
+}

--- a/Private/Find-WinADGroupCircularChain.ps1
+++ b/Private/Find-WinADGroupCircularChain.ps1
@@ -1,0 +1,79 @@
+﻿function Find-WinADGroupCircularChain {
+    <#
+    .SYNOPSIS
+    Finds a nested membership chain leading from one group back to another, if one exists.
+
+    .DESCRIPTION
+    Finds a nested membership chain leading from one group back to another by walking the requested membership attribute breadth-first.
+    Used to decide whether a group that was already visited on another branch of a traversal really closes a circle with the current group,
+    or is simply reachable over more than one path (which is not circular).
+    Already resolved objects are taken from the provided cache; unresolved objects are queried once and added to the cache.
+
+    .PARAMETER From
+    Distinguished name of the group to start walking from.
+
+    .PARAMETER To
+    Distinguished name of the group to find. When found, the chain of distinguished names from From to To is returned. Otherwise an empty array is returned.
+
+    .PARAMETER Attribute
+    Membership attribute to walk - Members (downwards) or MemberOf (upwards).
+
+    .PARAMETER Cache
+    Dictionary of already resolved AD objects, keyed by distinguished name.
+
+    .EXAMPLE
+    Find-WinADGroupCircularChain -From 'CN=GroupC,DC=ad,DC=local' -To 'CN=GroupA,DC=ad,DC=local' -Attribute 'Members' -Cache $Cache
+    Returns 'CN=GroupC,...', 'CN=GroupB,...', 'CN=GroupA,...' when GroupC contains GroupB which contains GroupA. Returns an empty array when GroupC does not lead to GroupA.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $From,
+        [Parameter(Mandatory)][string] $To,
+        [Parameter(Mandatory)][ValidateSet('Members', 'MemberOf')][string] $Attribute,
+        [Parameter(Mandatory)][System.Collections.IDictionary] $Cache
+    )
+    if (-not $Script:WinADCircularChainMemo) {
+        $Script:WinADCircularChainMemo = @{}
+    }
+    # A finished walk that found nothing leaves behind everything reachable from its starting group,
+    # so repeated walks from the same group (a group nested under many parents) are answered without walking again
+    $MemoKey = "$Attribute|$From"
+    $KnownClosure = $Script:WinADCircularChainMemo[$MemoKey]
+    if ($KnownClosure -and -not $KnownClosure.Contains($To)) {
+        return , ([string[]] @())
+    }
+    $Visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $Parent = @{}
+    $Queue = [System.Collections.Generic.Queue[string]]::new()
+    $null = $Visited.Add($From)
+    $Queue.Enqueue($From)
+    while ($Queue.Count -gt 0) {
+        $CurrentDN = $Queue.Dequeue()
+        if ($CurrentDN -eq $To) {
+            $Chain = [System.Collections.Generic.List[string]]::new()
+            $Step = $CurrentDN
+            while ($null -ne $Step) {
+                $Chain.Insert(0, $Step)
+                $Step = $Parent[$Step]
+            }
+            return , $Chain.ToArray()
+        }
+        $CurrentObject = $Cache[$CurrentDN]
+        if (-not $CurrentObject -and -not $Cache.Contains($CurrentDN)) {
+            $CurrentObject = Get-WinADObject -Identity $CurrentDN -IncludeGroupMembership:($Attribute -eq 'Members')
+            # Cache even when nothing was found, the same way the traversal loops do, so failing lookups are not repeated
+            $Cache[$CurrentDN] = $CurrentObject
+        }
+        if ($CurrentObject -and $CurrentObject.ObjectClass -eq 'group') {
+            foreach ($NextDN in $CurrentObject.$Attribute) {
+                if ($NextDN -and -not $Visited.Contains($NextDN)) {
+                    $null = $Visited.Add($NextDN)
+                    $Parent[$NextDN] = $CurrentDN
+                    $Queue.Enqueue($NextDN)
+                }
+            }
+        }
+    }
+    $Script:WinADCircularChainMemo[$MemoKey] = $Visited
+    return , ([string[]] @())
+}

--- a/Private/Find-WinADGroupCircularChain.ps1
+++ b/Private/Find-WinADGroupCircularChain.ps1
@@ -8,12 +8,24 @@
     Used to decide whether a group that was already visited on another branch of a traversal really closes a circle with the current group,
     or is simply reachable over more than one path (which is not circular).
     Already resolved objects are taken from the provided cache; unresolved objects are queried once and added to the cache.
+    Only groups are expanded and enqueued - objects the cache already knows are not groups cannot continue a circle,
+    so large flat memberships do not consume the search budget.
+
+    The walk is bounded. It inspects at most MaximumNodes objects and gives up with Status 'LimitReached' when the budget
+    is exhausted, so an unfinished search is never mistaken for a proven non-circle. Walks that finish without finding the
+    target remember everything reachable from the starting group in $Script:WinADCircularChainMemo (so a group nested under
+    many parents is checked once, not once per parent), and the total number of retained references is capped - once the
+    cap is reached further walks simply run without memoization instead of growing memory.
+
+    Returns an object with two properties:
+    - Status : 'Found' (Chain holds the membership chain), 'NotFound' (proven - no chain exists), 'LimitReached' (unknown - budget exhausted)
+    - Chain  : chain of distinguished names from From to To; empty unless Status is 'Found'
 
     .PARAMETER From
     Distinguished name of the group to start walking from.
 
     .PARAMETER To
-    Distinguished name of the group to find. When found, the chain of distinguished names from From to To is returned. Otherwise an empty array is returned.
+    Distinguished name of the group to find.
 
     .PARAMETER Attribute
     Membership attribute to walk - Members (downwards) or MemberOf (upwards).
@@ -21,32 +33,47 @@
     .PARAMETER Cache
     Dictionary of already resolved AD objects, keyed by distinguished name.
 
+    .PARAMETER MaximumNodes
+    Maximum number of objects the walk may inspect before giving up with Status 'LimitReached'.
+    Defaults to $Script:WinADCircularChainMaximumNodes when that variable is set, otherwise 5000.
+
+    .PARAMETER MaximumMemoWeight
+    Maximum total number of distinguished-name references kept across all memoized walk results.
+    Defaults to $Script:WinADCircularChainMemoMaximumWeight when that variable is set, otherwise 100000.
+
     .EXAMPLE
     Find-WinADGroupCircularChain -From 'CN=GroupC,DC=ad,DC=local' -To 'CN=GroupA,DC=ad,DC=local' -Attribute 'Members' -Cache $Cache
-    Returns 'CN=GroupC,...', 'CN=GroupB,...', 'CN=GroupA,...' when GroupC contains GroupB which contains GroupA. Returns an empty array when GroupC does not lead to GroupA.
+    Returns Status 'Found' with Chain 'CN=GroupC,...', 'CN=GroupB,...', 'CN=GroupA,...' when GroupC contains GroupB which contains GroupA.
+    Returns Status 'NotFound' with an empty Chain when GroupC provably does not lead to GroupA.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $From,
         [Parameter(Mandatory)][string] $To,
         [Parameter(Mandatory)][ValidateSet('Members', 'MemberOf')][string] $Attribute,
-        [Parameter(Mandatory)][System.Collections.IDictionary] $Cache
+        [Parameter(Mandatory)][System.Collections.IDictionary] $Cache,
+        [int] $MaximumNodes = $(if ($Script:WinADCircularChainMaximumNodes) { $Script:WinADCircularChainMaximumNodes } else { 5000 }),
+        [int] $MaximumMemoWeight = $(if ($Script:WinADCircularChainMemoMaximumWeight) { $Script:WinADCircularChainMemoMaximumWeight } else { 100000 })
     )
     if (-not $Script:WinADCircularChainMemo) {
         $Script:WinADCircularChainMemo = @{}
+    }
+    if (-not $Script:WinADCircularChainMemoWeight) {
+        $Script:WinADCircularChainMemoWeight = 0
     }
     # A finished walk that found nothing leaves behind everything reachable from its starting group,
     # so repeated walks from the same group (a group nested under many parents) are answered without walking again
     $MemoKey = "$Attribute|$From"
     $KnownClosure = $Script:WinADCircularChainMemo[$MemoKey]
     if ($KnownClosure -and -not $KnownClosure.Contains($To)) {
-        return , ([string[]] @())
+        return [PSCustomObject] @{ Status = 'NotFound'; Chain = [string[]] @() }
     }
     $Visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $Parent = @{}
     $Queue = [System.Collections.Generic.Queue[string]]::new()
     $null = $Visited.Add($From)
     $Queue.Enqueue($From)
+    $InspectedNodes = 0
     while ($Queue.Count -gt 0) {
         $CurrentDN = $Queue.Dequeue()
         if ($CurrentDN -eq $To) {
@@ -56,7 +83,18 @@
                 $Chain.Insert(0, $Step)
                 $Step = $Parent[$Step]
             }
-            return , $Chain.ToArray()
+            return [PSCustomObject] @{ Status = 'Found'; Chain = $Chain.ToArray() }
+        }
+        $InspectedNodes++
+        if ($InspectedNodes -gt $MaximumNodes) {
+            # Budget exhausted - report honestly instead of letting an unfinished walk pass for a proven non-circle
+            if (-not $Script:WinADCircularChainWarned) {
+                $Script:WinADCircularChainWarned = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            }
+            if ($Script:WinADCircularChainWarned.Add($MemoKey)) {
+                Write-Warning "Find-WinADGroupCircularChain - Circular check starting from '$From' stopped after inspecting $MaximumNodes objects and is reported as unverified. Set `$Script:WinADCircularChainMaximumNodes to a higher value to walk further."
+            }
+            return [PSCustomObject] @{ Status = 'LimitReached'; Chain = [string[]] @() }
         }
         $CurrentObject = $Cache[$CurrentDN]
         if (-not $CurrentObject -and -not $Cache.Contains($CurrentDN)) {
@@ -67,6 +105,13 @@
         if ($CurrentObject -and $CurrentObject.ObjectClass -eq 'group') {
             foreach ($NextDN in $CurrentObject.$Attribute) {
                 if ($NextDN -and -not $Visited.Contains($NextDN)) {
+                    if ($NextDN -ne $To -and $Cache.Contains($NextDN)) {
+                        $NextObject = $Cache[$NextDN]
+                        if (-not $NextObject -or $NextObject.ObjectClass -ne 'group') {
+                            # Known non-groups and unresolvable objects cannot continue a circle of groups - skip without spending budget
+                            continue
+                        }
+                    }
                     $null = $Visited.Add($NextDN)
                     $Parent[$NextDN] = $CurrentDN
                     $Queue.Enqueue($NextDN)
@@ -74,6 +119,9 @@
             }
         }
     }
-    $Script:WinADCircularChainMemo[$MemoKey] = $Visited
-    return , ([string[]] @())
+    if (($Script:WinADCircularChainMemoWeight + $Visited.Count) -le $MaximumMemoWeight) {
+        $Script:WinADCircularChainMemo[$MemoKey] = $Visited
+        $Script:WinADCircularChainMemoWeight += $Visited.Count
+    }
+    return [PSCustomObject] @{ Status = 'NotFound'; Chain = [string[]] @() }
 }

--- a/Public/Get-WinADGroupMember.ps1
+++ b/Public/Get-WinADGroupMember.ps1
@@ -60,6 +60,8 @@
         if (-not $Script:WinADGroupMemberCache -or $ClearCache) {
             $Script:WinADGroupMemberCache = @{}
             $Script:WinADCircularChainMemo = @{}
+            $Script:WinADCircularChainMemoWeight = 0
+            $Script:WinADCircularChainWarned = $null
             $Forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
             $Script:WinADForestCache = @{
                 Forest  = $Forest
@@ -223,6 +225,7 @@
 
                         # Chain of groups proving this row closes a real circle - stays empty when it does not
                         [string[]] $CircularChain = @()
+                        $CircularCheck = $null
                         if ($CurrentNestingPath -contains $NestedMember.DistinguishedName) {
                             # NestedMember is already an ancestor in the membership chain that led here - a real circular membership
                             $CycleStart = $CurrentNestingPath.Count - 1
@@ -231,19 +234,28 @@
                             }
                             $CircularChain = $CurrentNestingPath[$CycleStart..($CurrentNestingPath.Count - 1)]
                             if (@($CircularChain | Select-Object -Unique).Count -ne $CircularChain.Count) {
-                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it
-                                $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it.
+                                # The membership is proven circular either way, so if the bounded walk gives up the slice is kept.
+                                $TighterCheck = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                                if ($TighterCheck.Status -eq 'Found') {
+                                    $CircularChain = $TighterCheck.Chain
+                                }
                             }
                         } elseif ($CollectedGroups -contains $NestedMember.DistinguishedName) {
                             # NestedMember was already visited on another branch. That alone is not circular (it may simply be
                             # reachable over more than one path), but the branch that visited it first may have been cut short,
                             # so verify whether it really leads back to the current group
-                            $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                            $CircularCheck = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                            $CircularChain = $CircularCheck.Chain
                         }
                         if ($CircularChain.Count -gt 0 -and ($CircularChain.Count -ge 3 -or -not $CreatedObject['CircularDirect'])) {
                             # A chain of 2 is the direct pair itself which CircularDirect already describes
                             $CreatedObject['CircularIndirect'] = $true
                             $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName ($CircularChain + $NestedMember.DistinguishedName) -Cache $Script:WinADGroupMemberCache
+                        } elseif ($CircularCheck -and $CircularCheck.Status -eq 'LimitReached') {
+                            # The bounded walk gave up before proving or disproving a circle - report unknown rather than clean
+                            $CreatedObject['CircularIndirect'] = $null
+                            $CreatedObject['CircularPath'] = 'Unverified - search limit reached'
                         }
                         if ($All) {
                             [PSCustomObject] $CreatedObject

--- a/Public/Get-WinADGroupMember.ps1
+++ b/Public/Get-WinADGroupMember.ps1
@@ -52,12 +52,14 @@
         [Parameter(DontShow)][System.Collections.Generic.List[object]] $CollectedGroups,
         [Parameter(DontShow)][System.Object] $Circular,
         [Parameter(DontShow)][System.Collections.IDictionary] $InitialGroup,
-        [Parameter(DontShow)][switch] $Nested
+        [Parameter(DontShow)][switch] $Nested,
+        [Parameter(DontShow)][string[]] $NestingPath = @()
     )
     Begin {
         $Properties = 'GroupName', 'Name', 'SamAccountName', 'DisplayName', 'Enabled', 'Type', 'Nesting', 'CrossForest', 'ParentGroup', 'ParentGroupDomain', 'GroupDomainName', 'DistinguishedName', 'Sid'
         if (-not $Script:WinADGroupMemberCache -or $ClearCache) {
             $Script:WinADGroupMemberCache = @{}
+            $Script:WinADCircularChainMemo = @{}
             $Forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
             $Script:WinADForestCache = @{
                 Forest  = $Forest
@@ -89,6 +91,7 @@
                     Nesting           = $Nesting
                     CircularDirect    = $false
                     CircularIndirect  = $false
+                    CircularPath      = ''
                     CrossForest       = $false
                     ParentGroup       = ''
                     ParentGroupDomain = ''
@@ -98,6 +101,7 @@
                     Sid               = $null
                 }
                 $CollectedGroups = [System.Collections.Generic.List[string]]::new()
+                $NestingPath = @()
                 $Nesting = -1
             }
             $Nesting++
@@ -122,6 +126,8 @@
                 }
                 # Lets cache our object
                 $Script:WinADGroupMemberCache[$ADGroupName.DistinguishedName] = $ADGroupName
+                # Membership chain that led to this group - used to detect real circular membership
+                $CurrentNestingPath = $NestingPath + $ADGroupName.DistinguishedName
                 if ($Circular -or $CollectedGroups -contains $ADGroupName.DistinguishedName) {
                     Write-Verbose -Message "Get-WinADGroupMember - Group '$($ADGroupName.DistinguishedName)' has $($ADGroupName.Members.Count) members"
                     [Array] $NestedMembers = foreach ($MyIdentity in $ADGroupName.Members) {
@@ -194,6 +200,7 @@
                         Nesting           = $Nesting
                         CircularDirect    = $false
                         CircularIndirect  = $false
+                        CircularPath      = ''
                         CrossForest       = $false
                         ParentGroup       = $ADGroupName.name
                         ParentGroupDomain = $DomainParentGroup
@@ -209,18 +216,40 @@
                         if ($ADGroupName.memberof -contains $NestedMember.DistinguishedName) {
                             $Circular = $ADGroupName.DistinguishedName
                             $CreatedObject['CircularDirect'] = $true
+                            $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName @($ADGroupName.DistinguishedName, $NestedMember.DistinguishedName, $ADGroupName.DistinguishedName) -Cache $Script:WinADGroupMemberCache
                         }
 
                         $CollectedGroups.Add($ADGroupName.DistinguishedName)
 
-                        if ($CollectedGroups -contains $NestedMember.DistinguishedName) {
+                        # Chain of groups proving this row closes a real circle - stays empty when it does not
+                        [string[]] $CircularChain = @()
+                        if ($CurrentNestingPath -contains $NestedMember.DistinguishedName) {
+                            # NestedMember is already an ancestor in the membership chain that led here - a real circular membership
+                            $CycleStart = $CurrentNestingPath.Count - 1
+                            while ($CycleStart -gt 0 -and $CurrentNestingPath[$CycleStart] -ne $NestedMember.DistinguishedName) {
+                                $CycleStart--
+                            }
+                            $CircularChain = $CurrentNestingPath[$CycleStart..($CurrentNestingPath.Count - 1)]
+                            if (@($CircularChain | Select-Object -Unique).Count -ne $CircularChain.Count) {
+                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it
+                                $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                            }
+                        } elseif ($CollectedGroups -contains $NestedMember.DistinguishedName) {
+                            # NestedMember was already visited on another branch. That alone is not circular (it may simply be
+                            # reachable over more than one path), but the branch that visited it first may have been cut short,
+                            # so verify whether it really leads back to the current group
+                            $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $ADGroupName.DistinguishedName -Attribute 'Members' -Cache $Script:WinADGroupMemberCache
+                        }
+                        if ($CircularChain.Count -gt 0 -and ($CircularChain.Count -ge 3 -or -not $CreatedObject['CircularDirect'])) {
+                            # A chain of 2 is the direct pair itself which CircularDirect already describes
                             $CreatedObject['CircularIndirect'] = $true
+                            $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName ($CircularChain + $NestedMember.DistinguishedName) -Cache $Script:WinADGroupMemberCache
                         }
                         if ($All) {
                             [PSCustomObject] $CreatedObject
                         }
                         Write-Verbose "Get-WinADGroupMember - Going into $($NestedMember.DistinguishedName) (Nesting: $Nesting) (Circular:$Circular)"
-                        $OutputFromGroup = Get-WinADGroupMember -GroupName $NestedMember -Nesting $Nesting -Circular $Circular -InitialGroup $InitialGroup -CollectedGroups $CollectedGroups -Nested -All:$All.IsPresent #-CountMembers:$CountMembers.IsPresent
+                        $OutputFromGroup = Get-WinADGroupMember -GroupName $NestedMember -Nesting $Nesting -Circular $Circular -InitialGroup $InitialGroup -CollectedGroups $CollectedGroups -Nested -All:$All.IsPresent -NestingPath $CurrentNestingPath #-CountMembers:$CountMembers.IsPresent
                         if ($null -ne $OutputFromGroup) {
                             $OutputFromGroup
                         }

--- a/Public/Get-WinADGroupMemberOf.ps1
+++ b/Public/Get-WinADGroupMemberOf.ps1
@@ -38,6 +38,8 @@
         if (-not $Script:WinADGroupObjectCache -or $ClearCache) {
             $Script:WinADGroupObjectCache = @{}
             $Script:WinADCircularChainMemo = @{}
+            $Script:WinADCircularChainMemoWeight = 0
+            $Script:WinADCircularChainWarned = $null
         }
     }
     Process {
@@ -147,6 +149,7 @@
                         $CollectedGroups.Add($Object.DistinguishedName)
                         # Chain of groups proving this row closes a real circle - stays empty when it does not
                         [string[]] $CircularChain = @()
+                        $CircularCheck = $null
                         if ($CurrentNestingPath -contains $NestedMember.DistinguishedName) {
                             # NestedMember is already an ancestor in the membership chain that led here - a real circular membership
                             $CycleStart = $CurrentNestingPath.Count - 1
@@ -155,19 +158,28 @@
                             }
                             $CircularChain = $CurrentNestingPath[$CycleStart..($CurrentNestingPath.Count - 1)]
                             if (@($CircularChain | Select-Object -Unique).Count -ne $CircularChain.Count) {
-                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it
-                                $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it.
+                                # The membership is proven circular either way, so if the bounded walk gives up the slice is kept.
+                                $TighterCheck = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                                if ($TighterCheck.Status -eq 'Found') {
+                                    $CircularChain = $TighterCheck.Chain
+                                }
                             }
                         } elseif ($CollectedGroups -contains $NestedMember.DistinguishedName) {
                             # NestedMember was already visited on another branch. That alone is not circular (it may simply be
                             # reachable over more than one path), but the branch that visited it first may have been cut short,
                             # so verify whether it really leads back to the current object
-                            $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                            $CircularCheck = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                            $CircularChain = $CircularCheck.Chain
                         }
                         if ($CircularChain.Count -gt 0 -and ($CircularChain.Count -ge 3 -or -not $CreatedObject['CircularDirect'])) {
                             # A chain of 2 is the direct pair itself which CircularDirect already describes
                             $CreatedObject['CircularIndirect'] = $true
                             $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName ($CircularChain + $NestedMember.DistinguishedName) -Cache $Script:WinADGroupObjectCache
+                        } elseif ($CircularCheck -and $CircularCheck.Status -eq 'LimitReached') {
+                            # The bounded walk gave up before proving or disproving a circle - report unknown rather than clean
+                            $CreatedObject['CircularIndirect'] = $null
+                            $CreatedObject['CircularPath'] = 'Unverified - search limit reached'
                         }
 
                         [PSCustomObject] $CreatedObject

--- a/Public/Get-WinADGroupMemberOf.ps1
+++ b/Public/Get-WinADGroupMemberOf.ps1
@@ -31,11 +31,13 @@
         [Parameter(DontShow)][System.Collections.Generic.List[object]] $CollectedGroups,
         [Parameter(DontShow)][System.Object] $Circular,
         [Parameter(DontShow)][System.Collections.IDictionary] $InitialObject,
-        [Parameter(DontShow)][switch] $Nested
+        [Parameter(DontShow)][switch] $Nested,
+        [Parameter(DontShow)][string[]] $NestingPath = @()
     )
     Begin {
         if (-not $Script:WinADGroupObjectCache -or $ClearCache) {
             $Script:WinADGroupObjectCache = @{}
+            $Script:WinADCircularChainMemo = @{}
         }
     }
     Process {
@@ -57,6 +59,7 @@
                     Nesting              = $Nesting
                     CircularDirect       = $false
                     CircularIndirect     = $false
+                    CircularPath         = ''
                     #CrossForest          = $false
                     ParentGroup          = ''
                     ParentGroupDomain    = ''
@@ -66,6 +69,7 @@
                     Sid                  = $Object.ObjectSID
                 }
                 $CollectedGroups = [System.Collections.Generic.List[string]]::new()
+                $NestingPath = @()
                 $Nesting = -1
             }
 
@@ -74,6 +78,8 @@
             if ($Object) {
                 # Lets cache our object
                 $Script:WinADGroupObjectCache[$Object.DistinguishedName] = $Object
+                # Membership chain that led to this object - used to detect real circular membership
+                $CurrentNestingPath = $NestingPath + $Object.DistinguishedName
                 if ($Circular -or $CollectedGroups -contains $Object.DistinguishedName) {
                     [Array] $NestedMembers = foreach ($MyIdentity in $Object.MemberOf) {
                         if ($Script:WinADGroupObjectCache[$MyIdentity]) {
@@ -120,6 +126,7 @@
                         Nesting              = $Nesting
                         CircularDirect       = $false
                         CircularIndirect     = $false
+                        CircularPath         = ''
                         #CrossForest          = $false
                         ParentGroup          = $Object.name
                         ParentGroupDomain    = $Object.DomainName
@@ -135,16 +142,38 @@
                         if ($Object.members -contains $NestedMember.DistinguishedName) {
                             $Circular = $Object.DistinguishedName
                             $CreatedObject['CircularDirect'] = $true
+                            $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName @($Object.DistinguishedName, $NestedMember.DistinguishedName, $Object.DistinguishedName) -Cache $Script:WinADGroupObjectCache
                         }
                         $CollectedGroups.Add($Object.DistinguishedName)
-                        if ($CollectedGroups -contains $NestedMember.DistinguishedName) {
+                        # Chain of groups proving this row closes a real circle - stays empty when it does not
+                        [string[]] $CircularChain = @()
+                        if ($CurrentNestingPath -contains $NestedMember.DistinguishedName) {
+                            # NestedMember is already an ancestor in the membership chain that led here - a real circular membership
+                            $CycleStart = $CurrentNestingPath.Count - 1
+                            while ($CycleStart -gt 0 -and $CurrentNestingPath[$CycleStart] -ne $NestedMember.DistinguishedName) {
+                                $CycleStart--
+                            }
+                            $CircularChain = $CurrentNestingPath[$CycleStart..($CurrentNestingPath.Count - 1)]
+                            if (@($CircularChain | Select-Object -Unique).Count -ne $CircularChain.Count) {
+                                # The traversal path revisited a group so the slice is not the tightest circle - let the walk find it
+                                $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                            }
+                        } elseif ($CollectedGroups -contains $NestedMember.DistinguishedName) {
+                            # NestedMember was already visited on another branch. That alone is not circular (it may simply be
+                            # reachable over more than one path), but the branch that visited it first may have been cut short,
+                            # so verify whether it really leads back to the current object
+                            $CircularChain = Find-WinADGroupCircularChain -From $NestedMember.DistinguishedName -To $Object.DistinguishedName -Attribute 'MemberOf' -Cache $Script:WinADGroupObjectCache
+                        }
+                        if ($CircularChain.Count -gt 0 -and ($CircularChain.Count -ge 3 -or -not $CreatedObject['CircularDirect'])) {
+                            # A chain of 2 is the direct pair itself which CircularDirect already describes
                             $CreatedObject['CircularIndirect'] = $true
+                            $CreatedObject['CircularPath'] = ConvertTo-WinADCircularPath -DistinguishedName ($CircularChain + $NestedMember.DistinguishedName) -Cache $Script:WinADGroupObjectCache
                         }
 
                         [PSCustomObject] $CreatedObject
                         Write-Verbose "Get-WinADGroupMemberOf - Going deeper with $($NestedMember.SamAccountName)"
                         try {
-                            $OutputFromGroup = Get-WinADGroupMemberOf -Identity $NestedMember -Nesting $Nesting -Circular $Circular -InitialObject $InitialObject -CollectedGroups $CollectedGroups -Nested
+                            $OutputFromGroup = Get-WinADGroupMemberOf -Identity $NestedMember -Nesting $Nesting -Circular $Circular -InitialObject $InitialObject -CollectedGroups $CollectedGroups -Nested -NestingPath $CurrentNestingPath
                         } catch {
                             Write-Warning "Get-WinADGroupMemberOf - Going deeper with $($NestedMember.SamAccountName) failed $($_.Exception.Message)"
                         }

--- a/Tests/Get-WinADGroupMemberCircular.Tests.ps1
+++ b/Tests/Get-WinADGroupMemberCircular.Tests.ps1
@@ -1,0 +1,218 @@
+﻿# Tests for circular-membership detection in Get-WinADGroupMember / Get-WinADGroupMemberOf (issue #39).
+# The functions under test are dot-sourced directly and Get-WinADObject is replaced with an in-memory
+# group graph, because Get-WinADObject is called module-internally and cannot be mocked across the
+# module boundary - and circular group graphs are not practical to create in a real test domain.
+BeforeAll {
+    . "$PSScriptRoot\..\Private\ConvertTo-WinADCircularPath.ps1"
+    . "$PSScriptRoot\..\Private\Find-WinADGroupCircularChain.ps1"
+    . "$PSScriptRoot\..\Public\Get-WinADGroupMember.ps1"
+    . "$PSScriptRoot\..\Public\Get-WinADGroupMemberOf.ps1"
+
+    function ConvertFrom-DistinguishedName {
+        [CmdletBinding()] param($DistinguishedName, [switch] $ToDomainCN)
+        'test.local'
+    }
+    function Get-WinADObject {
+        [CmdletBinding()]
+        param([Parameter(Position = 0)] $Identity, [switch] $IncludeGroupMembership)
+        foreach ($Item in $Identity) {
+            if ($Item -is [System.Management.Automation.PSObject] -and $Item.PSObject.Properties['DistinguishedName'] -and $Item.DistinguishedName) {
+                $DN = $Item.DistinguishedName
+            } else {
+                $DN = "$Item"
+                if (-not $Script:TestGraph.ContainsKey($DN)) {
+                    $Found = $Script:TestGraph.Values | Where-Object { $_.Name -eq "$Item" } | Select-Object -First 1
+                    if ($Found) { $DN = $Found.DistinguishedName }
+                }
+            }
+            $Script:TestGraph[$DN]
+        }
+    }
+    function Get-TestDN([string] $Name) { "CN=$Name,DC=test,DC=local" }
+    function Set-TestGraph {
+        # $Members maps group name -> member names; MemberOf is derived. Names listed in $Users become user objects.
+        param([System.Collections.IDictionary] $Members, [string[]] $Users = @())
+        $Script:TestGraph = @{}
+        $AllNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($GroupName in $Members.Keys) {
+            $null = $AllNames.Add($GroupName)
+            foreach ($MemberName in $Members[$GroupName]) { $null = $AllNames.Add($MemberName) }
+        }
+        foreach ($Name in $AllNames) {
+            $Script:TestGraph[(Get-TestDN $Name)] = [PSCustomObject] @{
+                Name              = $Name
+                SamAccountName    = $Name
+                DisplayName       = $Name
+                Enabled           = $true
+                ObjectClass       = if ($Users -contains $Name) { 'user' } else { 'group' }
+                GroupType         = 'Security'
+                GroupScope        = 'Universal'
+                DomainName        = 'test.local'
+                DistinguishedName = (Get-TestDN $Name)
+                ObjectSID         = "S-1-5-21-0-0-0-$Name"
+                Members           = @(foreach ($MemberName in $Members[$Name]) { Get-TestDN $MemberName })
+                MemberOf          = @(foreach ($GroupName in $Members.Keys) { if ($Members[$GroupName] -contains $Name) { Get-TestDN $GroupName } })
+            }
+        }
+        # Prime the module-level caches so the functions skip forest discovery and start clean per test
+        $Script:WinADGroupMemberCache = @{}
+        $Script:WinADGroupObjectCache = @{}
+        $Script:WinADCircularChainMemo = @{}
+        $Script:WinADCircularChainMemoWeight = 0
+        $Script:WinADCircularChainWarned = $null
+        $Script:WinADCircularChainMaximumNodes = $null
+        $Script:WinADCircularChainMemoMaximumWeight = $null
+        $Script:WinADForestCache = @{ Forest = $null; Domains = @('test.local') }
+    }
+}
+
+Describe 'Issue #39 diamond (multi-path nesting) is not circular' {
+    BeforeEach {
+        # A contains B; B contains C and D; C contains D - two paths to D, no circle
+        Set-TestGraph -Members ([ordered] @{ A = 'B'; B = 'C', 'D'; C = 'D' })
+    }
+    It 'Get-WinADGroupMemberOf from D reports no circular membership' {
+        $Results = Get-WinADGroupMemberOf -Identity 'D'
+        $Results.Count | Should -Be 5
+        $Results.CircularDirect | Should -Not -Contain $true
+        $Results.CircularIndirect | Should -Not -Contain $true
+        ($Results.CircularPath | Where-Object { $_ }) | Should -BeNullOrEmpty
+    }
+    It 'Get-WinADGroupMember from A reports no circular membership' {
+        $Results = Get-WinADGroupMember -Identity 'A' -All
+        $Results.CircularDirect | Should -Not -Contain $true
+        $Results.CircularIndirect | Should -Not -Contain $true
+        ($Results.CircularPath | Where-Object { $_ }) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Direct circular membership' {
+    It 'flags a mutual pair with the pair chain in both directions' {
+        Set-TestGraph -Members ([ordered] @{ X = 'Y'; Y = 'X' })
+        $MemberRows = Get-WinADGroupMember -Identity 'X' -All
+        @($MemberRows | Where-Object { $_.CircularDirect }).Count | Should -BeGreaterThan 0
+        @($MemberRows | Where-Object { $_.CircularDirect })[0].CircularPath | Should -Be 'X -> Y -> X'
+        $MemberOfRows = Get-WinADGroupMemberOf -Identity 'X'
+        @($MemberOfRows | Where-Object { $_.CircularDirect }).Count | Should -BeGreaterThan 0
+    }
+    It 'flags self-membership as direct only' {
+        Set-TestGraph -Members ([ordered] @{ A = 'A', 'B'; B = @() })
+        $Rows = Get-WinADGroupMember -Identity 'A' -All
+        $SelfRow = @($Rows | Where-Object { $_.ParentGroup -eq 'A' -and $_.Name -eq 'A' })
+        $SelfRow.Count | Should -Be 1
+        $SelfRow[0].CircularDirect | Should -BeTrue
+        $SelfRow[0].CircularIndirect | Should -BeFalse
+        $SelfRow[0].CircularPath | Should -Be 'A -> A -> A'
+    }
+}
+
+Describe 'Indirect three-group circle' {
+    BeforeEach {
+        Set-TestGraph -Members ([ordered] @{ G1 = 'G2'; G2 = 'G3'; G3 = 'G1' })
+    }
+    It 'is flagged exactly once with the full circle rendered (Members direction)' {
+        $Rows = Get-WinADGroupMember -Identity 'G1' -All
+        $Flagged = @($Rows | Where-Object { $_.CircularIndirect })
+        $Flagged.Count | Should -Be 1
+        $Flagged[0].CircularPath | Should -Be 'G1 -> G2 -> G3 -> G1'
+        $Rows.CircularDirect | Should -Not -Contain $true
+    }
+    It 'is flagged exactly once with the full circle rendered (MemberOf direction)' {
+        $Rows = Get-WinADGroupMemberOf -Identity 'G1'
+        $Flagged = @($Rows | Where-Object { $_.CircularIndirect })
+        $Flagged.Count | Should -Be 1
+        $Flagged[0].CircularPath | Should -Be 'G1 -> G3 -> G2 -> G1'
+    }
+}
+
+Describe 'Diamond combined with a real circle' {
+    It 'flags each real circle once and leaves the diamond re-visit unflagged' {
+        # A>B>C>D>A is a circle; B also contains D directly, creating a diamond on top of it
+        Set-TestGraph -Members ([ordered] @{ A = 'B'; B = 'C', 'D'; C = 'D'; D = 'A' })
+        $Rows = Get-WinADGroupMember -Identity 'A' -All
+        $Flagged = @($Rows | Where-Object { $_.CircularIndirect })
+        $Flagged.Count | Should -Be 2
+        @($Flagged | Where-Object { $_.CircularPath -eq 'A -> B -> C -> D -> A' }).Count | Should -Be 1
+        @($Flagged | Where-Object { $_.CircularPath -eq 'D -> A -> B -> D' }).Count | Should -Be 1
+    }
+}
+
+Describe 'Circle hidden behind loop-prevention truncation' {
+    It 'is still reported once with its full chain' {
+        # S>M>Q, Q<->D2 (direct pair triggers truncation), Q>P, S>R>P, P>M closes M>Q>P>M
+        Set-TestGraph -Members ([ordered] @{ S = 'M', 'R'; M = 'Q'; Q = 'D2', 'P'; D2 = 'Q'; R = 'P'; P = 'M' })
+        $Rows = Get-WinADGroupMember -Identity 'S' -All
+        $Flagged = @($Rows | Where-Object { $_.CircularIndirect })
+        $Flagged.Count | Should -Be 1
+        $Flagged[0].CircularPath | Should -Be 'M -> Q -> P -> M'
+    }
+}
+
+Describe 'Traversal path that revisits a group' {
+    It 'renders the tightest simple circle instead of a walk with repeats' {
+        Set-TestGraph -Members ([ordered] @{ R = 'A'; A = 'B', 'X'; B = 'C'; C = 'A'; X = 'R' })
+        $Rows = Get-WinADGroupMember -Identity 'R' -All
+        $XRRow = @($Rows | Where-Object { $_.ParentGroup -eq 'X' -and $_.Name -eq 'R' -and $_.CircularIndirect })
+        $XRRow.Count | Should -BeGreaterThan 0
+        $XRRow[0].CircularPath | Should -Be 'R -> A -> X -> R'
+    }
+}
+
+Describe 'Bounded circular search' {
+    BeforeEach {
+        # Diamond head S>H via two parents, H tops a chain of groups so the verification walk has real work
+        Set-TestGraph -Members ([ordered] @{ S = 'P1', 'P2'; P1 = 'H'; P2 = 'H'; H = 'C1'; C1 = 'C2'; C2 = 'C3'; C3 = 'C4'; C4 = @() })
+    }
+    It 'helper reports LimitReached with a warning when the budget is too small' {
+        $Warnings = $null
+        $Result = Find-WinADGroupCircularChain -From (Get-TestDN 'H') -To (Get-TestDN 'P2') -Attribute 'Members' -Cache $Script:WinADGroupMemberCache -MaximumNodes 2 -WarningVariable Warnings -WarningAction SilentlyContinue
+        $Result.Status | Should -Be 'LimitReached'
+        $Result.Chain.Count | Should -Be 0
+        "$Warnings" | Should -Match 'unverified'
+        $Script:WinADCircularChainMemo.Count | Should -Be 0   # an unfinished walk must not be memoized
+    }
+    It 'helper proves NotFound and memoizes when the budget suffices' {
+        $Result = Find-WinADGroupCircularChain -From (Get-TestDN 'H') -To (Get-TestDN 'P2') -Attribute 'Members' -Cache $Script:WinADGroupMemberCache -MaximumNodes 50
+        $Result.Status | Should -Be 'NotFound'
+        $Script:WinADCircularChainMemo.Count | Should -Be 1
+        $Script:WinADCircularChainMemoWeight | Should -BeGreaterThan 0
+    }
+    It 'reports the row as unverified instead of clean when the walk is cut short' {
+        $Script:WinADCircularChainMaximumNodes = 2
+        $Rows = Get-WinADGroupMember -Identity 'S' -All -WarningAction SilentlyContinue
+        $HRows = @($Rows | Where-Object { $_.Name -eq 'H' })
+        $Unverified = @($HRows | Where-Object { $_.CircularPath -eq 'Unverified - search limit reached' })
+        $Unverified.Count | Should -Be 1
+        $Unverified[0].CircularIndirect | Should -BeNullOrEmpty   # unknown - neither proven nor disproven
+        ($Rows | Where-Object { $_.CircularIndirect }) | Should -BeNullOrEmpty
+    }
+    It 'flags the same row normally when the budget suffices' {
+        $Rows = Get-WinADGroupMember -Identity 'S' -All
+        @($Rows | Where-Object { $_.CircularPath -eq 'Unverified - search limit reached' }).Count | Should -Be 0
+        @($Rows | Where-Object { $_.CircularIndirect }).Count | Should -Be 0
+        @($Rows | Where-Object { $_.CircularIndirect -eq $null -and $_.Type -eq 'group' }).Count | Should -Be 0
+    }
+    It 'a truncation-hidden circle degrades to unverified, never to a silent pass' {
+        Set-TestGraph -Members ([ordered] @{ S = 'M', 'R'; M = 'Q'; Q = 'D2', 'P'; D2 = 'Q'; R = 'P'; P = 'M' })
+        $Script:WinADCircularChainMaximumNodes = 1
+        $Rows = Get-WinADGroupMember -Identity 'S' -All -WarningAction SilentlyContinue
+        @($Rows | Where-Object { $_.CircularIndirect }).Count | Should -Be 0
+        @($Rows | Where-Object { $_.CircularPath -eq 'Unverified - search limit reached' }).Count | Should -BeGreaterThan 0
+    }
+    It 'does not spend budget on user objects in flat groups' {
+        $Members = [ordered] @{ S = 'P1', 'P2'; P1 = 'H'; P2 = 'H'; H = @(foreach ($i in 1..50) { "User$i" }) }
+        Set-TestGraph -Members $Members -Users @(foreach ($i in 1..50) { "User$i" })
+        $Script:WinADCircularChainMaximumNodes = 5
+        $Rows = Get-WinADGroupMember -Identity 'S' -All
+        # 50 users would exhaust a budget of 5 if they were enqueued; only groups may consume it
+        @($Rows | Where-Object { $_.CircularPath -eq 'Unverified - search limit reached' }).Count | Should -Be 0
+        @($Rows | Where-Object { $_.CircularIndirect }).Count | Should -Be 0
+    }
+    It 'stops growing the memo once the weight cap is reached' {
+        $Script:WinADCircularChainMemoMaximumWeight = 3
+        $Result = Find-WinADGroupCircularChain -From (Get-TestDN 'H') -To (Get-TestDN 'P2') -Attribute 'Members' -Cache $Script:WinADGroupMemberCache -MaximumNodes 50
+        $Result.Status | Should -Be 'NotFound'
+        $Script:WinADCircularChainMemo.Count | Should -Be 0   # closure of 5 groups exceeds the cap of 3
+        $Script:WinADCircularChainMemoWeight | Should -Be 0
+    }
+}


### PR DESCRIPTION
Fixes #39

## What this changes

`CircularIndirect` in `Get-WinADGroupMember` and `Get-WinADGroupMemberOf` currently fires whenever a nested group was *already visited anywhere* in the traversal (`$CollectedGroups`), which flags perfectly legal multi-path nesting as circular. The repro from #39:

```powershell
"A","B","C","D" | ForEach-Object { New-ADGroup $_ -GroupScope Universal }
Add-ADGroupMember A -Members "B"
Add-ADGroupMember B -Members "C","D"
Add-ADGroupMember C -Members "D"

Get-WinADGroupMemberOf D -ClearCache | Select-Object ObjectName, ParentGroup, Name, CircularIndirect, CircularPath
```

Before: the `D -> B` row reports `CircularIndirect = True` although nothing is circular. After: no row is flagged, and truly circular memberships are reported with the actual circle:

| ParentGroup | Name | CircularDirect | CircularIndirect | CircularPath |
|---|---|---|---|---|
| G3 | G1 | False | True | G1 -> G2 -> G3 -> G1 |

## How it works

Traversal, recursion, truncation and row emission are **untouched** — `$CollectedGroups` keeps doing its loop-prevention job exactly as before, so the rows you get are identical to master. Only the flag logic changed:

1. A new per-branch `$NestingPath` (internal `DontShow` parameter) carries the chain of groups that led to the current row. If the nested member is already an ancestor on that chain, the row closes a real circle — flag it and render the chain.
2. If the member is merely *already visited* (the old false-positive trigger), a new private helper `Find-WinADGroupCircularChain` walks the actual `Members`/`MemberOf` attributes breadth-first (using the module's existing object cache, querying uncached objects the same way the main loop does) to check whether that group really leads back to the current one. Diamonds fail this check and stay unflagged; genuine circles that the traversal happened to walk in an unlucky order are still found and reported with their full chain. Without this second check, a real circle could go completely unreported when the `$Circular` truncation cuts the branch that would have walked it end-to-end — the old visited-based flag accidentally still hinted at those.
3. `CircularDirect` behavior is unchanged. When an edge closes *both* a direct pair and a longer circle (e.g. `P <-> W` plus `W > V > P > W`), the row now carries both flags, with `CircularPath` showing the longer circle (the pair is already described by the row itself).

New output column `CircularPath` (from the #39 discussion) renders the proven circle as `Name -> Name -> ... -> Name`. Names come from the object cache, so no extra queries; if an object ever isn't cached, the DN is used as a fallback. I went with `Name` rather than DN to keep it readable with long group names — happy to switch or add a DN variant if you prefer.

New private helpers (auto-loaded by the existing `Private\*.ps1` dot-sourcing, nothing to register):

- `ConvertTo-WinADCircularPath` — renders a DN chain as a readable name path
- `Find-WinADGroupCircularChain` — BFS reachability check between two groups over `Members`/`MemberOf`. It reuses the module's existing object caches (caching failed lookups the same way the traversal loops do, so orphaned/unresolvable DNs are never re-queried), and memoizes exhausted no-circle walks per starting group, so a shared group nested under many parents is checked once, not once per parent. The memo lives next to the object caches and resets with `-ClearCache`.

## Testing

Since circular graphs are awkward to build in a live domain, I tested with a stubbed `Get-WinADObject` simulating group graphs end-to-end through both public functions — 40 assertions across 9 scenario groups, passing on both PowerShell 7 and Windows PowerShell 5.1:

- the exact #39 diamond in both directions (no flags, identical rows to master)
- direct 2-cycles, self-membership, 3-group indirect cycles (correct flags + paths, terminates)
- diamond *plus* real cycle in one graph (each real cycle flagged once, diamond re-visit not flagged)
- a cycle hidden behind `$Circular` truncation (old code hinted it, path-only checking would have lost it, this PR reports it with its full chain)
- users/`AddSelf`/`SelfOnly`/users-only output shapes unchanged
- traversal paths that revisit a group still render the tightest simple circle (never `R -> A -> B -> C -> A -> X -> R`-style walks)

Beyond the scenario harness, I ran exhaustive differential sweeps against master: all 512 possible three-group digraphs (x2 member orderings, both functions) plus 1,500 randomized four-group graphs with users mixed in, on both editions — row sequences bit-identical to master everywhere, `CircularDirect` identical to master everywhere, every rendered `CircularPath` validated edge-by-edge as a real membership circle, and every cycle master hinted at still flagged. The HTML consumers (`Show-WinADGroupMember`, `Show-WinADGroupMemberOf`, `New-HTMLGroupDiagramHierachical`) only read the two booleans, so they now simply highlight fewer false alarms; the extra column flows through the report tables as-is.

Performance: the walk only runs on rows where a group is re-encountered (exactly the rows that used to be false-flagged), never issues a directory query the traversal would not have issued itself (verified by counting stubbed `Get-WinADObject` calls: identical to master in every scenario), and with the negative-walk memo the worst synthetic case measured (a shared group nested under 40 parents, 861 objects) runs at 542 ms vs master's 450 ms while removing 759 false-positive rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
