### PR TITLE
Add Mail to group membership output

### DIFF
--- a/Public/Get-WinADGroupMember.ps1
+++ b/Public/Get-WinADGroupMember.ps1
@@ -55,7 +55,7 @@
         [Parameter(DontShow)][switch] $Nested
     )
     Begin {
-        $Properties = 'GroupName', 'Name', 'SamAccountName', 'DisplayName', 'Enabled', 'Type', 'Nesting', 'CrossForest', 'ParentGroup', 'ParentGroupDomain', 'GroupDomainName', 'DistinguishedName', 'Sid'
+        $Properties = 'GroupName', 'Name', 'SamAccountName', 'DisplayName', 'Mail', 'Enabled', 'Type', 'Nesting', 'CrossForest', 'ParentGroup', 'ParentGroupDomain', 'GroupDomainName', 'DistinguishedName', 'Sid'
         if (-not $Script:WinADGroupMemberCache -or $ClearCache) {
             $Script:WinADGroupMemberCache = @{}
             $Forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
@@ -78,6 +78,7 @@
                     SamAccountName    = $null
                     DomainName        = $null
                     DisplayName       = $null
+                    Mail              = $null
                     Enabled           = $null
                     GroupType         = $null
                     GroupScope        = $null
@@ -113,6 +114,7 @@
                         $InitialGroup.Name = $ADGroupName.Name
                         $InitialGroup.SamAccountName = $ADGroupName.SamAccountName
                         $InitialGroup.DisplayName = $ADGroupName.DisplayName
+                        $InitialGroup.Mail = $ADGroupName.Mail
                         $InitialGroup.GroupDomainName = $ADGroupName.DomainName
                         $InitialGroup.DistinguishedName = $ADGroupName.DistinguishedName
                         $InitialGroup.Sid = $ADGroupName.ObjectSID
@@ -183,6 +185,7 @@
                         SamAccountName    = $NestedMember.SamAccountName
                         DomainName        = $NestedMember.DomainName #ConvertFrom-DistinguishedName -DistinguishedName $NestedMember.DistinguishedName -ToDomainCN
                         DisplayName       = $NestedMember.DisplayName
+                        Mail              = $NestedMember.Mail
                         Enabled           = $NestedMember.Enabled
                         GroupType         = $NestedMember.GroupType
                         GroupScope        = $NestedMember.GroupScope

--- a/Public/Get-WinADGroupMemberOf.ps1
+++ b/Public/Get-WinADGroupMemberOf.ps1
@@ -50,6 +50,7 @@
                     SamAccountName       = $Object.SamAccountName
                     DomainName           = $Object.DomainName
                     DisplayName          = $Object.DisplayName
+                    Mail                 = $Object.Mail
                     Enabled              = $Object.Enabled
                     Type                 = $Object.ObjectClass
                     GroupType            = $Object.GroupType
@@ -113,6 +114,7 @@
                         SamAccountName       = $NestedMember.SamAccountName
                         DomainName           = $NestedMember.DomainName
                         DisplayName          = $NestedMember.DisplayName
+                        Mail                 = $NestedMember.Mail
                         Enabled              = $NestedMember.Enabled
                         Type                 = $NestedMember.ObjectClass
                         GroupType            = $NestedMember.GroupType

--- a/Public/Get-WinADObject.ps1
+++ b/Public/Get-WinADObject.ps1
@@ -308,6 +308,7 @@
                     #Deleted             = $Object.properties.isDeleted -as [string]
                     #Recycled            = $Object.properties.isRecycled -as [string]
                     UserPrincipalName   = $Object.properties.userprincipalname -as [string]
+                    Mail                = $Object.properties.mail -as [string]
                     ObjectSID           = $ObjectSID
                     MemberOf            = $Object.properties.memberof -as [array]
                     Members             = $Members

--- a/Public/Show-WinADGroupMember.ps1
+++ b/Public/Show-WinADGroupMember.ps1
@@ -176,7 +176,7 @@
                         $SectionInformation = New-HTMLSection -Title "Information for $GroupName" {
                             New-HTMLTable -DataTable $ADGroup -Filtering -DataStoreID $DataStoreID {
                                 if (-not $DisableBuiltinConditions) {
-                                    New-TableHeader -Names Name, SamAccountName, DomainName, DisplayName -Title 'Member'
+                                    New-TableHeader -Names Name, SamAccountName, DomainName, DisplayName, Mail -Title 'Member'
                                     New-TableHeader -Names DirectMembers, DirectGroups, IndirectMembers, TotalMembers -Title 'Statistics'
                                     New-TableHeader -Names GroupType, GroupScope -Title 'Group Details'
                                     New-TableCondition -BackgroundColor CoralRed -Color White -ComparisonType bool -Value $false -Name Enabled -Operator eq

--- a/Public/Show-WinADGroupMemberOf.ps1
+++ b/Public/Show-WinADGroupMemberOf.ps1
@@ -115,7 +115,7 @@
                     $DataSection = New-HTMLSection -Title "Information for $ObjectName" {
                         New-HTMLTable -DataTable $MyObject -Filtering -DataStoreID $DataStoreID {
                             if (-not $DisableBuiltinConditions) {
-                                New-TableHeader -Names Name, SamAccountName, DomainName, DisplayName -Title 'Member'
+                                New-TableHeader -Names Name, SamAccountName, DomainName, DisplayName, Mail -Title 'Member'
                                 New-TableHeader -Names GroupType, GroupScope -Title 'Group Details'
                                 New-TableCondition -BackgroundColor CoralRed -Color White -ComparisonType bool -Value $false -Name Enabled -Operator eq
                                 New-TableCondition -BackgroundColor LightBlue -ComparisonType string -Value '' -Name ParentGroup -Operator eq -Row

--- a/Tests/Get-WinADGroupMemberMail.Tests.ps1
+++ b/Tests/Get-WinADGroupMemberMail.Tests.ps1
@@ -1,0 +1,110 @@
+﻿# Tests that the mail attribute flows through Get-WinADGroupMember / Get-WinADGroupMemberOf (issue #41).
+# The functions under test are dot-sourced directly and Get-WinADObject is replaced with an in-memory
+# graph, because Get-WinADObject is called module-internally and cannot be mocked across the module
+# boundary. This protects the additive output contract when the membership functions change again.
+BeforeAll {
+    . "$PSScriptRoot\..\Public\Get-WinADGroupMember.ps1"
+    . "$PSScriptRoot\..\Public\Get-WinADGroupMemberOf.ps1"
+
+    function ConvertFrom-DistinguishedName {
+        [CmdletBinding()] param($DistinguishedName, [switch] $ToDomainCN)
+        'test.local'
+    }
+    function Get-WinADObject {
+        [CmdletBinding()]
+        param([Parameter(Position = 0)] $Identity, [switch] $IncludeGroupMembership)
+        foreach ($Item in $Identity) {
+            if ($Item -is [System.Management.Automation.PSObject] -and $Item.PSObject.Properties['DistinguishedName'] -and $Item.DistinguishedName) {
+                $DN = $Item.DistinguishedName
+            } else {
+                $DN = "$Item"
+                if (-not $Script:TestGraph.ContainsKey($DN)) {
+                    $Found = $Script:TestGraph.Values | Where-Object { $_.Name -eq "$Item" } | Select-Object -First 1
+                    if ($Found) { $DN = $Found.DistinguishedName }
+                }
+            }
+            $Script:TestGraph[$DN]
+        }
+    }
+    function Get-TestDN([string] $Name) { "CN=$Name,DC=test,DC=local" }
+    function Add-TestObject {
+        param([string] $Name, [string[]] $Members = @(), [string[]] $MemberOf = @(), [string] $Class = 'group', [string] $Mail = '')
+        $Script:TestGraph[(Get-TestDN $Name)] = [PSCustomObject] @{
+            Name              = $Name
+            SamAccountName    = $Name
+            DisplayName       = $Name
+            Mail              = $Mail
+            Enabled           = $true
+            ObjectClass       = $Class
+            GroupType         = 'Distribution'
+            GroupScope        = 'Universal'
+            DomainName        = 'test.local'
+            DistinguishedName = (Get-TestDN $Name)
+            ObjectSID         = "S-1-5-21-0-0-0-$Name"
+            Members           = @(foreach ($MemberName in $Members) { Get-TestDN $MemberName })
+            MemberOf          = @(foreach ($GroupName in $MemberOf) { Get-TestDN $GroupName })
+        }
+    }
+    function Reset-TestState {
+        # A mail-enabled universal DL containing a mail-enabled nested group, a mail user and a mail-less user
+        $Script:TestGraph = @{}
+        Add-TestObject -Name 'DL-All' -Members 'DL-Sub', 'Joe' -Mail 'dl-all@contoso.com'
+        Add-TestObject -Name 'DL-Sub' -Members 'NoMailUser' -MemberOf 'DL-All' -Mail 'dl-sub@contoso.com'
+        Add-TestObject -Name 'Joe' -MemberOf 'DL-All' -Class 'user' -Mail 'joe@contoso.com'
+        Add-TestObject -Name 'NoMailUser' -MemberOf 'DL-Sub' -Class 'user'
+        # Prime the module-level caches so the functions skip forest discovery and start clean per test
+        $Script:WinADGroupMemberCache = @{}
+        $Script:WinADGroupObjectCache = @{}
+        $Script:WinADForestCache = @{ Forest = $null; Domains = @('test.local') }
+    }
+}
+
+Describe 'Mail attribute in Get-WinADGroupMember output' {
+    BeforeEach {
+        Reset-TestState
+    }
+    It 'carries the mail of the queried group on the AddSelf row' {
+        $Rows = Get-WinADGroupMember -Identity 'DL-All' -All -AddSelf
+        $SelfRow = @($Rows | Where-Object { $_.Nesting -eq -1 })
+        $SelfRow.Count | Should -Be 1
+        $SelfRow[0].Mail | Should -Be 'dl-all@contoso.com'
+    }
+    It 'carries the mail of nested groups and users on their rows' {
+        $Rows = Get-WinADGroupMember -Identity 'DL-All' -All
+        @($Rows | Where-Object { $_.Name -eq 'DL-Sub' })[0].Mail | Should -Be 'dl-sub@contoso.com'
+        @($Rows | Where-Object { $_.Name -eq 'Joe' })[0].Mail | Should -Be 'joe@contoso.com'
+    }
+    It 'leaves Mail empty for objects without the attribute' {
+        $Rows = Get-WinADGroupMember -Identity 'DL-All' -All
+        @($Rows | Where-Object { $_.Name -eq 'NoMailUser' })[0].Mail | Should -BeNullOrEmpty
+    }
+    It 'includes Mail in the users-only default output' {
+        $Rows = Get-WinADGroupMember -Identity 'DL-All'
+        @($Rows).Count | Should -Be 2
+        $Rows[0].PSObject.Properties['Mail'] | Should -Not -BeNullOrEmpty
+        @($Rows | Where-Object { $_.Name -eq 'Joe' })[0].Mail | Should -Be 'joe@contoso.com'
+    }
+}
+
+Describe 'Mail attribute in Get-WinADGroupMemberOf output' {
+    BeforeEach {
+        Reset-TestState
+    }
+    It 'carries the mail of each parent group on its row' {
+        $Rows = Get-WinADGroupMemberOf -Identity 'NoMailUser'
+        @($Rows | Where-Object { $_.Name -eq 'DL-Sub' })[0].Mail | Should -Be 'dl-sub@contoso.com'
+        @($Rows | Where-Object { $_.Name -eq 'DL-All' })[0].Mail | Should -Be 'dl-all@contoso.com'
+    }
+    It 'carries the mail of the queried object on the AddSelf row' {
+        $Rows = Get-WinADGroupMemberOf -Identity 'Joe' -AddSelf
+        $SelfRow = @($Rows | Where-Object { $_.Nesting -eq -1 })
+        $SelfRow.Count | Should -Be 1
+        $SelfRow[0].Mail | Should -Be 'joe@contoso.com'
+    }
+    It 'leaves Mail empty on the AddSelf row of a mail-less object' {
+        $Rows = Get-WinADGroupMemberOf -Identity 'NoMailUser' -AddSelf
+        $SelfRow = @($Rows | Where-Object { $_.Nesting -eq -1 })
+        $SelfRow.Count | Should -Be 1
+        $SelfRow[0].Mail | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
Fixes #41

Surfaces the `mail` attribute so universal groups used as distribution lists show their address in group reporting.

## What this changes

- `Get-WinADObject` now includes `Mail` in its output object. The existing ADSI `DirectorySearcher` has no `PropertiesToLoad` restriction, so `mail` was already coming back from LDAP with every query — this just stops dropping it. No extra directory cost.
- `Get-WinADGroupMember` and `Get-WinADGroupMemberOf` carry `Mail` on every row (groups, users, computers), placed right after `DisplayName`, including the group's own row with `-AddSelf`/`-SelfOnly` — which is the distribution-list case from #41. The users-only default output of `Get-WinADGroupMember` includes it too.
- `Show-WinADGroupMember` / `Show-WinADGroupMemberOf` HTML reports pick the column up automatically from the row objects; the only edit there is adding `Mail` to the `Member` header group so it lands under the right super-header.

## Testing

Tested end-to-end through both public functions with a stubbed `Get-WinADObject` simulating a mail-enabled DL containing a mail-enabled nested group, a mail user and a mail-less user — mail flows to member rows, memberOf rows, the AddSelf row, and the users-only output; empty when the attribute isn't set. Passing on PowerShell 7 and Windows PowerShell 5.1. Also swept every consumer of `Get-WinADObject` output in the repo (report builders, diagram builders, ACL/trust functions, tests) to confirm the added property is purely additive — all of them access properties by name, and the `New-TableHeader` groups in the Show reports stay contiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
