### PR TITLE
Fix Test-WinADObjectReplicationStatus selecting no DCs without -GlobalCatalog

### DIFF
--- a/Public/Test-WinADObjectReplicationStatus.ps1
+++ b/Public/Test-WinADObjectReplicationStatus.ps1
@@ -53,7 +53,7 @@
         Write-Warning "Test-WinADObjectReplicationStatus - Object not found. Try again later or check the object does exists."
         return
     }
-    $DomainFromIdentity = $ObjectInformation.Domain
+    $DomainFromIdentity = $ObjectInformation.DomainName
     $DistinguishedName = $ObjectInformation.DistinguishedName
 
     $ForestInformation = Get-WinADForestDetails -Extended -PreferWritable

--- a/Tests/Test-WinADObjectReplicationStatus.Tests.ps1
+++ b/Tests/Test-WinADObjectReplicationStatus.Tests.ps1
@@ -1,0 +1,75 @@
+﻿# Regression tests for Test-WinADObjectReplicationStatus DC selection (PR #84).
+# The previous defect read $ObjectInformation.Domain (a property Get-WinADObject never emits, the key
+# is DomainName), so the non-GlobalCatalog path matched zero domain controllers and returned an empty
+# result WITHOUT throwing - exactly the failure mode a test must guard against. The function is
+# dot-sourced with stubbed directory commands: a two-domain forest with two DCs per domain and the
+# object living in the child domain.
+BeforeAll {
+    . "$PSScriptRoot\..\Public\Test-WinADObjectReplicationStatus.ps1"
+
+    function Get-WinADObject {
+        [CmdletBinding()] param([Parameter(Position = 0)] $Identity)
+        [PSCustomObject] @{
+            Name              = 'TestUser'
+            SamAccountName    = 'TestUser'
+            DomainName        = 'child.test.local'   # Get-WinADObject emits DomainName - there is no Domain property
+            DistinguishedName = 'CN=TestUser,DC=child,DC=test,DC=local'
+            ObjectClass       = 'user'
+        }
+    }
+    function Get-WinADForestDetails {
+        [CmdletBinding()] param([switch] $Extended, [switch] $PreferWritable)
+        [PSCustomObject] @{
+            ForestDomainControllers = @(
+                [PSCustomObject] @{ HostName = 'dc1.test.local'; Domain = 'test.local'; IsGlobalCatalog = $true }
+                [PSCustomObject] @{ HostName = 'dc2.test.local'; Domain = 'test.local'; IsGlobalCatalog = $false }
+                [PSCustomObject] @{ HostName = 'dc1.child.test.local'; Domain = 'child.test.local'; IsGlobalCatalog = $true }
+                [PSCustomObject] @{ HostName = 'dc2.child.test.local'; Domain = 'child.test.local'; IsGlobalCatalog = $false }
+            )
+        }
+    }
+    function Get-ADObject {
+        [CmdletBinding()] param($Identity, $Server, $Properties)
+        $Script:QueriedServers.Add($Server)
+        [PSCustomObject] @{
+            userAccountCOntrol = 512
+            Created            = [datetime] '2026-01-01'
+            uSNChanged         = 100
+            uSNCreated         = 50
+            whenCreated        = [datetime] '2026-01-01'
+            WhenChanged        = [datetime] '2026-06-01'
+        }
+    }
+}
+
+Describe 'Test-WinADObjectReplicationStatus DC selection' {
+    BeforeEach {
+        $Script:QueriedServers = [System.Collections.Generic.List[string]]::new()
+    }
+    It 'queries every writable DC of the object''s own domain without -GlobalCatalog' {
+        $Results = Test-WinADObjectReplicationStatus -Identity 'TestUser'
+        # The pre-fix code selected zero DCs here and returned nothing, silently
+        @($Results).Count | Should -Be 2
+        $Script:QueriedServers.Count | Should -Be 2
+        $Script:QueriedServers | Should -Contain 'dc1.child.test.local'
+        $Script:QueriedServers | Should -Contain 'dc2.child.test.local'
+    }
+    It 'does not query domain controllers from other domains' {
+        $null = Test-WinADObjectReplicationStatus -Identity 'TestUser'
+        $Script:QueriedServers | Should -Not -Contain 'dc1.test.local'
+        $Script:QueriedServers | Should -Not -Contain 'dc2.test.local'
+    }
+    It 'returns rows that carry the object''s domain and data from each DC' {
+        $Results = Test-WinADObjectReplicationStatus -Identity 'TestUser'
+        @($Results | Where-Object { $_.Domain -eq 'child.test.local' }).Count | Should -Be 2
+        @($Results | Where-Object { $null -ne $_.WhenChanged }).Count | Should -Be 2
+        ($Results.Error | Where-Object { $_ }) | Should -BeNullOrEmpty
+    }
+    It 'still queries all global catalogs on port 3268 with -GlobalCatalog' {
+        $Results = Test-WinADObjectReplicationStatus -Identity 'TestUser' -GlobalCatalog
+        @($Results).Count | Should -Be 2
+        $Script:QueriedServers.Count | Should -Be 2
+        $Script:QueriedServers | Should -Contain 'dc1.test.local:3268'
+        $Script:QueriedServers | Should -Contain 'dc1.child.test.local:3268'
+    }
+}


### PR DESCRIPTION
Fixes #85

## The bug

`Test-WinADObjectReplicationStatus` without `-GlobalCatalog` always queries **zero** domain controllers and returns nothing.

Line 56 reads `$ObjectInformation.Domain`, but `Get-WinADObject` has never emitted a `Domain` property — its output key is `DomainName`. So `$DomainFromIdentity` is always `$null`, and the DC filter:

```powershell
if ($DC.Domain -eq $DomainFromIdentity) {
```

matches no writable DCs (the `ForestDomainControllers` objects from `Get-WinADForestDetails` carry the domain FQDN in `Domain`, which never equals `$null`).

## The fix

One word — read `DomainName` instead:

```powershell
$DomainFromIdentity = $ObjectInformation.DomainName
```

Both sides of the comparison are the domain FQDN produced by `ConvertFrom-DistinguishedName -ToDomainCN`, which is also exactly how the sibling function `Find-WinADObjectDifference` (line 199) feeds the identical filter, confirming the intended comparison. The `-GlobalCatalog` path is untouched.

## Verification

Stubbed `Get-WinADObject` / `Get-WinADForestDetails` / `Get-ADObject` with a two-domain forest (2 DCs each, object in the child domain) and ran the function end-to-end on PowerShell 7 and Windows PowerShell 5.1:

- master: 0 DCs queried, no output (bug reproduced)
- fixed: exactly the 2 child-domain DCs queried, correct rows returned
- `-GlobalCatalog`: still queries the 2 GCs on port 3268, unchanged

Repo-wide grep confirms this was the only `$ObjectInformation.Domain` read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)