### PR TITLE
Add CustomIcons for keyword-based diagram node icons

### DIFF
--- a/Private/Get-WinADCustomDiagramIcon.ps1
+++ b/Private/Get-WinADCustomDiagramIcon.ps1
@@ -1,0 +1,88 @@
+﻿function Get-WinADCustomDiagramIcon {
+    <#
+    .SYNOPSIS
+    Resolves a custom diagram icon for an object based on wildcard name patterns.
+
+    .DESCRIPTION
+    Resolves a custom diagram icon for an object based on wildcard name patterns provided by the user.
+    Returns a hashtable ready to be splatted onto New-DiagramNode, or $null when no pattern matches
+    (in which case the caller falls back to the default icon for the object type).
+    The first matching pattern wins - provide an [ordered] dictionary to control precedence.
+    Icon names are validated against the PSWriteHTML icon dictionary when it is loaded; unknown names
+    and invalid wildcard patterns produce a single warning and fall back to default icons.
+
+    .PARAMETER Name
+    Name of the object (user, group, computer) to match against the patterns.
+
+    .PARAMETER CustomIcons
+    Dictionary where each key is a wildcard pattern matched against the object name (-like) and each value is either:
+    - a string with an image URL, or
+    - a dictionary with Image, or IconSolid/IconRegular/IconBrands (Font Awesome icon name) plus optional IconColor.
+
+    .EXAMPLE
+    Get-WinADCustomDiagramIcon -Name 'GG-RBAC-FileShares' -CustomIcons ([ordered] @{ '*-RBAC-*' = 'https://cdn-icons-png.flaticon.com/512/1687/1687242.png' })
+    Returns @{ Image = 'https://cdn-icons-png.flaticon.com/512/1687/1687242.png' }
+
+    .EXAMPLE
+    Get-WinADCustomDiagramIcon -Name 'Enterprise Admins' -CustomIcons ([ordered] @{ 'Enterprise Admins' = @{ IconSolid = 'user-shield'; IconColor = 'Red' } })
+    Returns @{ IconSolid = 'user-shield'; IconColor = 'Red' }
+    #>
+    [CmdletBinding()]
+    param(
+        [string] $Name,
+        [System.Collections.IDictionary] $CustomIcons
+    )
+    if (-not $CustomIcons -or -not $Name) {
+        return $null
+    }
+    if (-not $Script:WinADCustomDiagramIconWarnings) {
+        $Script:WinADCustomDiagramIconWarnings = [System.Collections.Generic.HashSet[string]]::new()
+    }
+    foreach ($Pattern in $CustomIcons.Keys) {
+        try {
+            $PatternMatched = $Name -like $Pattern
+        } catch {
+            if ($Script:WinADCustomDiagramIconWarnings.Add("Pattern|$Pattern")) {
+                Write-Warning "Get-WinADCustomDiagramIcon - Invalid wildcard pattern '$Pattern' in CustomIcons. Skipping it."
+            }
+            continue
+        }
+        if ($PatternMatched) {
+            $Value = $CustomIcons[$Pattern]
+            if ($Value -is [System.Collections.IDictionary]) {
+                if ($Value['Image']) {
+                    return @{ Image = [string] $Value['Image'] }
+                }
+                $IconSplat = @{}
+                foreach ($IconType in 'IconSolid', 'IconRegular', 'IconBrands') {
+                    if ($Value[$IconType]) {
+                        $IconName = [string] $Value[$IconType]
+                        # New-DiagramNode validates icon names against the PSWriteHTML icon dictionary,
+                        # and a failing name would silently drop the node while keeping its links.
+                        # Verify upfront so a typo falls back to the default icon instead.
+                        $IconDictionary = if ($Global:HTMLIcons) { $Global:HTMLIcons["FontAwesome$($IconType.Substring(4))"] } else { $null }
+                        if ($IconDictionary -and -not $IconDictionary.Contains($IconName)) {
+                            if ($Script:WinADCustomDiagramIconWarnings.Add("Icon|$IconName")) {
+                                Write-Warning "Get-WinADCustomDiagramIcon - Icon '$IconName' ($IconType) for pattern '$Pattern' does not exist in the PSWriteHTML icon set. Using default icon."
+                            }
+                            return $null
+                        }
+                        $IconSplat[$IconType] = $IconName
+                        break
+                    }
+                }
+                if ($IconSplat.Count -gt 0) {
+                    if ($Value['IconColor']) {
+                        $IconSplat['IconColor'] = [string] $Value['IconColor']
+                    }
+                    return $IconSplat
+                }
+            } elseif ($Value -is [string] -and $Value) {
+                return @{ Image = $Value }
+            }
+            # matched pattern without a usable value - fall back to default icons
+            return $null
+        }
+    }
+    return $null
+}

--- a/Private/Get-WinADCustomDiagramIcon.ps1
+++ b/Private/Get-WinADCustomDiagramIcon.ps1
@@ -10,6 +10,8 @@
     The first matching pattern wins - provide an [ordered] dictionary to control precedence.
     Icon names are validated against the PSWriteHTML icon dictionary when it is loaded; unknown names
     and invalid wildcard patterns produce a single warning and fall back to default icons.
+    URL-backed images require network access when the generated report is opened; Font Awesome
+    overrides are self-contained and the right choice for offline reports.
 
     .PARAMETER Name
     Name of the object (user, group, computer) to match against the patterns.

--- a/Private/New-HTMLGroupDiagramDefault.ps1
+++ b/Private/New-HTMLGroupDiagramDefault.ps1
@@ -50,7 +50,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         #if ($DataTableID) {
@@ -68,10 +69,13 @@
                 #[int] $LevelParent = $($ADObject.Nesting)
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)"
 
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid user -IconColor LightSteelBlue
@@ -88,7 +92,13 @@
                     }
                     $SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                     $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine + $SummaryMembers
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -IconSolid user-friends -IconColor VeryLightGrey
@@ -97,7 +107,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray
@@ -107,7 +119,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon

--- a/Private/New-HTMLGroupDiagramHierachical.ps1
+++ b/Private/New-HTMLGroupDiagramHierachical.ps1
@@ -49,7 +49,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         New-DiagramOptionsLayout -HierarchicalEnabled $true #-HierarchicalDirection FromLeftToRight #-HierarchicalSortMethod directed
@@ -65,10 +66,13 @@
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)$LevelParent"
 
                 [int] $Level = $($ADObject.Nesting) + 1
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user -IconColor LightSteelBlue
@@ -95,7 +99,13 @@
                     } else {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine + $SummaryMembers
                     }
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -Level $Level -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid $IconSolid -IconColor $BorderColor
@@ -104,7 +114,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray -Level $Level
@@ -114,7 +126,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon -Level $Level

--- a/Private/New-HTMLGroupDiagramSummary.ps1
+++ b/Private/New-HTMLGroupDiagramSummary.ps1
@@ -47,7 +47,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     $ConnectionsTracker = @{}
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
@@ -72,10 +73,13 @@
                     $ConnectionsTracker[$ID] = @{}
                 }
                 if (-not $ConnectionsTracker[$ID][$IDParent]) {
+                    $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                     if ($ADObject.Type -eq 'User') {
                         if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid user -IconColor LightSteelBlue
@@ -92,7 +96,13 @@
                         }
                         $SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine + $SummaryMembers
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            if ($CustomIconSplat.Image) {
+                                # keep the border cue distinguishing the queried group from nested ones
+                                $CustomIconSplat.ColorBorder = $BorderColor
+                            }
+                            New-DiagramNode -Id $ID -Label $Label -ArrowsToEnabled @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Image -ArrowsToEnabled -ColorBorder $BorderColor
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -ArrowsToEnabled -IconSolid user-friends -IconColor VeryLightGrey
@@ -101,7 +111,9 @@
                     } elseif ($ADObject.Type -eq 'Computer') {
                         if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray
@@ -111,7 +123,9 @@
                     } else {
                         if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon

--- a/Private/New-HTMLGroupDiagramSummaryHierarchical.ps1
+++ b/Private/New-HTMLGroupDiagramSummaryHierarchical.ps1
@@ -39,7 +39,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         New-DiagramOptionsLayout -HierarchicalEnabled $true #-HierarchicalDirection FromLeftToRight #-HierarchicalSortMethod directed
@@ -57,10 +58,13 @@
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)"
 
                 [int] $Level = $($ADObject.Nesting) + 1
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user -IconColor LightSteelBlue
@@ -77,7 +81,13 @@
                     }
                     $SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                     $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine + $SummaryMembers
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -Level $Level -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user-friends
@@ -86,7 +96,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray -Level $Level
@@ -96,7 +108,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon -Level $Level

--- a/Private/New-HTMLGroupOfDiagramDefault.ps1
+++ b/Private/New-HTMLGroupOfDiagramDefault.ps1
@@ -51,7 +51,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         #if ($DataTableID) {
@@ -69,10 +70,13 @@
                 #[int] $LevelParent = $($ADObject.Nesting)
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)"
 
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid user -IconColor LightSteelBlue
@@ -89,7 +93,13 @@
                     }
                     #$SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                     $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine #+ $SummaryMembers
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -IconSolid user-friends -IconColor VeryLightGrey
@@ -98,7 +108,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray
@@ -108,7 +120,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Default') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon

--- a/Private/New-HTMLGroupOfDiagramHierarchical.ps1
+++ b/Private/New-HTMLGroupOfDiagramHierarchical.ps1
@@ -42,7 +42,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         New-DiagramOptionsLayout -HierarchicalEnabled $true #-HierarchicalDirection FromLeftToRight #-HierarchicalSortMethod directed
@@ -58,10 +59,13 @@
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)$LevelParent"
 
                 [int] $Level = $($ADObject.Nesting) + 1
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user -IconColor LightSteelBlue
@@ -78,7 +82,13 @@
                     }
                     # $SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                     $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine # + $SummaryMembers
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -Level $Level -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user-friends
@@ -87,7 +97,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray -Level $Level
@@ -97,7 +109,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon -Level $Level

--- a/Private/New-HTMLGroupOfDiagramSummary.ps1
+++ b/Private/New-HTMLGroupOfDiagramSummary.ps1
@@ -51,7 +51,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     $ConnectionsTracker = @{}
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
@@ -76,10 +77,13 @@
                     $ConnectionsTracker[$ID] = @{}
                 }
                 if (-not $ConnectionsTracker[$ID][$IDParent]) {
+                    $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                     if ($ADObject.Type -eq 'User') {
                         if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid user -IconColor LightSteelBlue
@@ -96,7 +100,13 @@
                         }
                         #$SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine #+ $SummaryMembers
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            if ($CustomIconSplat.Image) {
+                                # keep the border cue distinguishing the queried group from nested ones
+                                $CustomIconSplat.ColorBorder = $BorderColor
+                            }
+                            New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Image -ColorBorder $BorderColor
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid user-friends -IconColor VeryLightGrey
@@ -105,7 +115,9 @@
                     } elseif ($ADObject.Type -eq 'Computer') {
                         if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray
@@ -115,7 +127,9 @@
                     } else {
                         if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Default') {
                             $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                            if ($Online) {
+                            if ($CustomIconSplat) {
+                                New-DiagramNode -Id $ID -Label $Label @CustomIconSplat
+                            } elseif ($Online) {
                                 New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther
                             } else {
                                 New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon

--- a/Private/New-HTMLGroupOfDiagramSummaryHierarchical.ps1
+++ b/Private/New-HTMLGroupOfDiagramSummaryHierarchical.ps1
@@ -39,7 +39,8 @@
         [switch] $Online,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     New-HTMLDiagram -Height 'calc(100vh - 200px)' {
         New-DiagramOptionsLayout -HierarchicalEnabled $true #-HierarchicalDirection FromLeftToRight #-HierarchicalSortMethod directed
@@ -57,10 +58,13 @@
                 $IDParent = "$($ADObject.ParentGroupDomain)$($ADObject.ParentGroupDN)"
 
                 [int] $Level = $($ADObject.Nesting) + 1
+                $CustomIconSplat = Get-WinADCustomDiagramIcon -Name $ADObject.Name -CustomIcons $CustomIcons
                 if ($ADObject.Type -eq 'User') {
                     if (-not $HideUsers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageUser -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user -IconColor LightSteelBlue
@@ -77,7 +81,13 @@
                     }
                     #$SummaryMembers = -join ('Total: ', $ADObject.TotalMembers, ' Direct: ', $ADObject.DirectMembers, ' Groups: ', $ADObject.DirectGroups, ' Indirect: ', $ADObject.IndirectMembers)
                     $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName + [System.Environment]::NewLine #+ $SummaryMembers
-                    if ($Online) {
+                    if ($CustomIconSplat) {
+                        if ($CustomIconSplat.Image) {
+                            # keep the border cue distinguishing the queried group from nested ones
+                            $CustomIconSplat.ColorBorder = $BorderColor
+                        }
+                        New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                    } elseif ($Online) {
                         New-DiagramNode -Id $ID -Label $Label -Image $Image -Level $Level -ColorBorder $BorderColor
                     } else {
                         New-DiagramNode -Id $ID -Label $Label -Level $Level -IconSolid user-friends
@@ -86,7 +96,9 @@
                 } elseif ($ADObject.Type -eq 'Computer') {
                     if (-not $HideComputers -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageComputer -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid desktop -IconColor LightGray -Level $Level
@@ -96,7 +108,9 @@
                 } else {
                     if (-not $HideOther -or $HideAppliesTo -notin 'Both', 'Hierarchical') {
                         $Label = $ADObject.Name + [System.Environment]::NewLine + $ADObject.DomainName
-                        if ($Online) {
+                        if ($CustomIconSplat) {
+                            New-DiagramNode -Id $ID -Label $Label -Level $Level @CustomIconSplat
+                        } elseif ($Online) {
                             New-DiagramNode -Id $ID -Label $Label -Image $Script:ConfigurationIcons.ImageOther -Level $Level
                         } else {
                             New-DiagramNode -Id $ID -Label $Label -IconSolid robot -IconColor LightSalmon -Level $Level

--- a/Public/Show-WinADGroupMember.ps1
+++ b/Public/Show-WinADGroupMember.ps1
@@ -67,6 +67,7 @@
     or a dictionary with Image, or IconSolid/IconRegular/IconBrands (Font Awesome icon name) plus optional IconColor.
     The first matching pattern wins - provide an [ordered] dictionary to control precedence. Objects without a match keep default icons.
     Patterns use -like semantics, so a literal [ or ] in an object name must be escaped with a backtick in the pattern.
+    URL-backed images still require network access when the generated report is opened; Font Awesome overrides are self-contained and the right choice for offline reports.
 
     .EXAMPLE
    Show-WinADGroupMember -GroupName 'Domain Admins' -FilePath $PSScriptRoot\Reports\GroupMembership1.html -Online -Verbose

--- a/Public/Show-WinADGroupMember.ps1
+++ b/Public/Show-WinADGroupMember.ps1
@@ -61,6 +61,13 @@
     .PARAMETER ScrollX
     Adds horizontal scroll to the table. Useful when there are many columns.
 
+    .PARAMETER CustomIcons
+    Dictionary of wildcard patterns matched against object names to override diagram node icons.
+    Each key is a wildcard pattern (compared with -like) and each value is either a string with an image URL,
+    or a dictionary with Image, or IconSolid/IconRegular/IconBrands (Font Awesome icon name) plus optional IconColor.
+    The first matching pattern wins - provide an [ordered] dictionary to control precedence. Objects without a match keep default icons.
+    Patterns use -like semantics, so a literal [ or ] in an object name must be escaped with a backtick in the pattern.
+
     .EXAMPLE
    Show-WinADGroupMember -GroupName 'Domain Admins' -FilePath $PSScriptRoot\Reports\GroupMembership1.html -Online -Verbose
 
@@ -72,6 +79,13 @@
 
    .EXAMPLE
    Show-WinADGroupMember -GroupName 'Group1' -Verbose -Online
+
+   .EXAMPLE
+   Show-WinADGroupMember -GroupName 'Domain Admins' -Online -CustomIcons ([ordered] @{
+       '*-RBAC-*'          = 'https://cdn-icons-png.flaticon.com/512/1687/1687242.png'
+       'Enterprise Admins' = @{ IconSolid = 'user-shield'; IconColor = 'Red' }
+       '*ADMIN*'           = @{ Image = 'https://cdn-icons-png.flaticon.com/512/2206/2206368.png' }
+   })
 
     .NOTES
     General notes
@@ -96,7 +110,8 @@
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
         [int] $DiagramFilteringMinimumCharacters = 3,
-        [switch] $ScrollX
+        [switch] $ScrollX,
+        [System.Collections.IDictionary] $CustomIcons
     )
     $Script:Reporting = [ordered] @{}
     $Script:Reporting['Version'] = Get-GitHubVersion -Cmdlet 'Show-WinADGroupMember' -RepositoryOwner 'evotecit' -RepositoryName 'ADEssentials'
@@ -201,13 +216,13 @@
                             Write-Verbose -Message "Show-WinADGroupMember - processing HTML generation for $Group group - Diagram"
                             New-HTMLTab -TabName 'Diagram Basic' {
                                 New-HTMLSection -Title "Diagram for $GroupName" {
-                                    New-HTMLGroupDiagramDefault -ADGroup $ADGroup -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                                    New-HTMLGroupDiagramDefault -ADGroup $ADGroup -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                                 }
                             }
                             Write-Verbose -Message "Show-WinADGroupMember - processing HTML generation for $Group group - Diagram Hierarchy"
                             New-HTMLTab -TabName 'Diagram Hierarchy' {
                                 New-HTMLSection -Title "Diagram for $GroupName" {
-                                    New-HTMLGroupDiagramHierachical -ADGroup $ADGroup -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                                    New-HTMLGroupDiagramHierachical -ADGroup $ADGroup -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                                 }
                             }
                         }
@@ -219,12 +234,12 @@
                 New-HTMLTab -Name 'Summary' {
                     New-HTMLTab -TabName 'Diagram Basic' {
                         New-HTMLSection -Title "Diagram for Summary" {
-                            New-HTMLGroupDiagramSummary -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                            New-HTMLGroupDiagramSummary -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                         }
                     }
                     New-HTMLTab -TabName 'Diagram Hierarchy' {
                         New-HTMLSection -Title "Diagram for Summary" {
-                            New-HTMLGroupDiagramSummaryHierarchical -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                            New-HTMLGroupDiagramSummaryHierarchical -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                         }
                     }
                 }

--- a/Public/Show-WinADGroupMemberOf.ps1
+++ b/Public/Show-WinADGroupMemberOf.ps1
@@ -48,6 +48,7 @@
     or a dictionary with Image, or IconSolid/IconRegular/IconBrands (Font Awesome icon name) plus optional IconColor.
     The first matching pattern wins - provide an [ordered] dictionary to control precedence. Objects without a match keep default icons.
     Patterns use -like semantics, so a literal [ or ] in an object name must be escaped with a backtick in the pattern.
+    URL-backed images still require network access when the generated report is opened; Font Awesome overrides are self-contained and the right choice for offline reports.
 
     .EXAMPLE
     Show-WinADGroupMemberOf -Identity 'przemyslaw.klys' -Verbose -Summary

--- a/Public/Show-WinADGroupMemberOf.ps1
+++ b/Public/Show-WinADGroupMemberOf.ps1
@@ -42,11 +42,24 @@
     .PARAMETER EnableDiagramFilteringButton
     Adds button to enable/disable filtering in diagrams. It's extension to EnableDiagramFiltering, when you prefer button over automatic filtering.
 
+    .PARAMETER CustomIcons
+    Dictionary of wildcard patterns matched against object names to override diagram node icons.
+    Each key is a wildcard pattern (compared with -like) and each value is either a string with an image URL,
+    or a dictionary with Image, or IconSolid/IconRegular/IconBrands (Font Awesome icon name) plus optional IconColor.
+    The first matching pattern wins - provide an [ordered] dictionary to control precedence. Objects without a match keep default icons.
+    Patterns use -like semantics, so a literal [ or ] in an object name must be escaped with a backtick in the pattern.
+
     .EXAMPLE
     Show-WinADGroupMemberOf -Identity 'przemyslaw.klys' -Verbose -Summary
 
     .EXAMPLE
     Show-WinADGroupMemberOf -Identity 'przemyslaw.klys', 'adm.pklys' -Summary
+
+    .EXAMPLE
+    Show-WinADGroupMemberOf -Identity 'adm.pklys' -Online -CustomIcons ([ordered] @{
+        '*-RBAC-*'          = 'https://cdn-icons-png.flaticon.com/512/1687/1687242.png'
+        'Enterprise Admins' = @{ IconSolid = 'user-shield'; IconColor = 'Red' }
+    })
 
     .NOTES
     General notes
@@ -65,7 +78,8 @@
         [switch] $SkipDiagram,
         [switch] $EnableDiagramFiltering,
         [switch] $EnableDiagramFilteringButton,
-        [int] $DiagramFilteringMinimumCharacters = 3
+        [int] $DiagramFilteringMinimumCharacters = 3,
+        [System.Collections.IDictionary] $CustomIcons
     )
     $HideAppliesTo = 'Both'
     $Script:Reporting = [ordered] @{}
@@ -136,13 +150,13 @@
                         Write-Verbose -Message "Show-WinADGroupMemberOf - Processing HTML generation for $ObjectName - Diagram"
                         New-HTMLTab -TabName 'Diagram Basic' {
                             New-HTMLSection -Title "Diagram for $ObjectName" {
-                                New-HTMLGroupOfDiagramDefault -Identity $MyObject -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                                New-HTMLGroupOfDiagramDefault -Identity $MyObject -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                             }
                         }
                         Write-Verbose -Message "Show-WinADGroupMemberOf - Processing HTML generation for $ObjectName - Diagram Hierarchy"
                         New-HTMLTab -TabName 'Diagram Hierarchy' {
                             New-HTMLSection -Title "Diagram for $ObjectName" {
-                                New-HTMLGroupOfDiagramHierarchical -Identity $MyObject -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                                New-HTMLGroupOfDiagramHierarchical -Identity $MyObject -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                             }
                         }
                     }
@@ -154,12 +168,12 @@
             New-HTMLTab -Name 'Summary' {
                 New-HTMLTab -TabName 'Diagram Basic' {
                     New-HTMLSection -Title "Diagram for Summary" {
-                        New-HTMLGroupOfDiagramSummary -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                        New-HTMLGroupOfDiagramSummary -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -DataTableID $DataTableID -ColumnID 1 -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                     }
                 }
                 New-HTMLTab -TabName 'Diagram Hierarchy' {
                     New-HTMLSection -Title "Diagram for Summary" {
-                        New-HTMLGroupOfDiagramSummaryHierarchical -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent
+                        New-HTMLGroupOfDiagramSummaryHierarchical -ADGroup $GroupsList -HideAppliesTo $HideAppliesTo -HideUsers:$HideUsers -HideComputers:$HideComputers -HideOther:$HideOther -Online:$Online -EnableDiagramFiltering:$EnableDiagramFiltering.IsPresent -DiagramFilteringMinimumCharacters $DiagramFilteringMinimumCharacters -EnableDiagramFilteringButton:$EnableDiagramFilteringButton.IsPresent -CustomIcons $CustomIcons
                     }
                 }
             }

--- a/Tests/Show-WinADGroupMemberCustomIcons.Tests.ps1
+++ b/Tests/Show-WinADGroupMemberCustomIcons.Tests.ps1
@@ -1,0 +1,221 @@
+﻿# Tests for the CustomIcons feature (issue #35): pattern resolution in Get-WinADCustomDiagramIcon and
+# propagation through Show-WinADGroupMember / Show-WinADGroupMemberOf into the diagram builders.
+# Functions are dot-sourced with the PSWriteHTML surface stubbed - New-DiagramNode records every node it
+# is asked to draw, scriptblock-hosting commands simply execute their content, everything else is a no-op.
+BeforeAll {
+    . "$PSScriptRoot\..\Private\Configuration.Icons.ps1"
+    . "$PSScriptRoot\..\Private\Get-WinADCustomDiagramIcon.ps1"
+    . "$PSScriptRoot\..\Private\New-HTMLGroupDiagramDefault.ps1"
+    . "$PSScriptRoot\..\Private\New-HTMLGroupDiagramHierachical.ps1"
+    . "$PSScriptRoot\..\Private\New-HTMLGroupOfDiagramDefault.ps1"
+    . "$PSScriptRoot\..\Private\New-HTMLGroupOfDiagramHierarchical.ps1"
+    . "$PSScriptRoot\..\Public\Show-WinADGroupMember.ps1"
+    . "$PSScriptRoot\..\Public\Show-WinADGroupMemberOf.ps1"
+    . "$PSScriptRoot\..\Public\Get-WinADGroupMemberOf.ps1"
+
+    $Script:OriginalHTMLIcons = $Global:HTMLIcons
+
+    # --- PSWriteHTML stubs: execute nested scriptblocks, record diagram nodes, ignore the rest ---
+    function New-HTML { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLHeader { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLSection { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLTab { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLTable { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLDiagram { foreach ($Arg in $args) { if ($Arg -is [scriptblock]) { & $Arg } } }
+    function New-HTMLText { }
+    function New-HTMLSectionStyle { }
+    function New-HTMLTableOption { }
+    function New-HTMLTabStyle { }
+    function New-TableHeader { }
+    function New-TableCondition { }
+    function New-DiagramOptionsLayout { }
+    function New-DiagramOptionsPhysics { }
+    function New-DiagramLink { }
+    function New-DiagramEvent { }
+    function New-DiagramNode {
+        param(
+            $Id, $Label, $Image, $Level, $ColorBorder,
+            $IconSolid, $IconRegular, $IconBrands, $IconColor,
+            [switch] $ArrowsToEnabled
+        )
+        $Script:CapturedNodes.Add([PSCustomObject] @{
+                Label      = "$Label" -split "`n" | Select-Object -First 1
+                Image      = $Image
+                IconSolid  = $IconSolid
+                IconBrands = $IconBrands
+                IconColor  = $IconColor
+            })
+    }
+    # --- Non-PSWriteHTML dependencies of the Show functions ---
+    function Get-GitHubVersion { '1.0.0' }
+    function Get-FileName { [System.IO.Path]::GetTempFileName() }
+    function Convert-DomainFqdnToNetBIOS { 'TEST' }
+    function Get-RandomStringName { 'teststring' }
+    function ConvertFrom-DistinguishedName { [CmdletBinding()] param($DistinguishedName, [switch] $ToDomainCN) 'test.local' }
+    function Get-WinADObject {
+        [CmdletBinding()]
+        param([Parameter(Position = 0)] $Identity, [switch] $IncludeGroupMembership)
+        foreach ($Item in $Identity) {
+            if ($Item -is [System.Management.Automation.PSObject] -and $Item.PSObject.Properties['DistinguishedName'] -and $Item.DistinguishedName) {
+                $DN = $Item.DistinguishedName
+            } else {
+                $DN = "$Item"
+                if (-not $Script:TestGraph.ContainsKey($DN)) {
+                    $Found = $Script:TestGraph.Values | Where-Object { $_.Name -eq "$Item" } | Select-Object -First 1
+                    if ($Found) { $DN = $Found.DistinguishedName }
+                }
+            }
+            $Script:TestGraph[$DN]
+        }
+    }
+    function Get-TestDN([string] $Name) { "CN=$Name,DC=test,DC=local" }
+    function New-TestRow {
+        # Row shaped like Get-WinADGroupMember -All -AddSelf output, for the visualize-only path of Show-WinADGroupMember
+        param([string] $Name, [string] $Type = 'Group', [int] $Nesting = 0, [string] $Parent = 'GG-RBAC-Root')
+        [PSCustomObject] @{
+            GroupName         = 'GG-RBAC-Root'
+            GroupDomainName   = 'test.local'
+            Name              = $Name
+            DomainName        = 'test.local'
+            DistinguishedName = (Get-TestDN $Name)
+            ParentGroupDomain = if ($Nesting -eq -1) { '' } else { 'test.local' }
+            ParentGroupDN     = if ($Nesting -eq -1) { '' } else { (Get-TestDN $Parent) }
+            Type              = $Type
+            Nesting           = $Nesting
+            CircularDirect    = $false
+            CircularIndirect  = $false
+            TotalMembers      = 3; DirectMembers = 2; DirectGroups = 1; IndirectMembers = 1
+        }
+    }
+}
+AfterAll {
+    $Global:HTMLIcons = $Script:OriginalHTMLIcons
+}
+
+Describe 'Get-WinADCustomDiagramIcon pattern resolution' {
+    BeforeEach {
+        $Script:WinADCustomDiagramIconWarnings = $null
+        $Global:HTMLIcons = @{
+            FontAwesomeSolid   = @{ 'user-shield' = 'f505'; 'users' = 'f0c0' }
+            FontAwesomeRegular = @{ 'user' = 'f007' }
+            FontAwesomeBrands  = @{ 'windows' = 'f17a' }
+        }
+    }
+    It 'first matching pattern wins in an ordered dictionary' {
+        $Icons = [ordered] @{ 'GG-*' = 'https://cdn/first.png'; '*RBAC*' = @{ IconSolid = 'users' } }
+        $Result = Get-WinADCustomDiagramIcon -Name 'GG-RBAC-FileShares' -CustomIcons $Icons
+        $Result.Image | Should -Be 'https://cdn/first.png'
+        $Result.Keys | Should -Not -Contain 'IconSolid'
+    }
+    It 'resolves a string value to an image and a dictionary value to an icon with color' {
+        (Get-WinADCustomDiagramIcon -Name 'AnyGroup' -CustomIcons @{ '*' = 'https://cdn/x.png' }).Image | Should -Be 'https://cdn/x.png'
+        $IconResult = Get-WinADCustomDiagramIcon -Name 'Enterprise Admins' -CustomIcons @{ 'Enterprise Admins' = @{ IconSolid = 'user-shield'; IconColor = 'Red' } }
+        $IconResult.IconSolid | Should -Be 'user-shield'
+        $IconResult.IconColor | Should -Be 'Red'
+        (Get-WinADCustomDiagramIcon -Name 'PC-01' -CustomIcons @{ 'PC-*' = @{ IconBrands = 'windows' } }).IconBrands | Should -Be 'windows'
+    }
+    It 'returns nothing when no pattern matches' {
+        Get-WinADCustomDiagramIcon -Name 'Unrelated' -CustomIcons @{ 'GG-*' = 'https://cdn/x.png' } | Should -BeNullOrEmpty
+    }
+    It 'skips an invalid wildcard pattern with one warning and still evaluates later patterns' {
+        $Warnings = $null
+        $Icons = [ordered] @{ 'Bad[' = 'https://cdn/never.png'; '*RBAC*' = 'https://cdn/rbac.png' }
+        $Result = Get-WinADCustomDiagramIcon -Name 'GG-RBAC-X' -CustomIcons $Icons -WarningVariable Warnings -WarningAction SilentlyContinue
+        $Result.Image | Should -Be 'https://cdn/rbac.png'
+        "$Warnings" | Should -Match 'Invalid wildcard'
+        # the warning is deduplicated on repeated calls
+        $Warnings2 = $null
+        $null = Get-WinADCustomDiagramIcon -Name 'GG-RBAC-X' -CustomIcons $Icons -WarningVariable Warnings2 -WarningAction SilentlyContinue
+        "$Warnings2" | Should -BeNullOrEmpty
+    }
+    It 'falls back to default icons with a warning when the icon name is not in the PSWriteHTML icon set' {
+        $Warnings = $null
+        $Result = Get-WinADCustomDiagramIcon -Name 'GG-RBAC-X' -CustomIcons @{ '*RBAC*' = @{ IconSolid = 'user-sheild' } } -WarningVariable Warnings -WarningAction SilentlyContinue
+        $Result | Should -BeNullOrEmpty
+        "$Warnings" | Should -Match 'does not exist'
+    }
+    It 'passes icon names through when the PSWriteHTML icon dictionary is not loaded' {
+        $Global:HTMLIcons = $null
+        (Get-WinADCustomDiagramIcon -Name 'X' -CustomIcons @{ 'X' = @{ IconSolid = 'anything-goes' } }).IconSolid | Should -Be 'anything-goes'
+    }
+    It 'treats a matched entry without a usable value as no override' {
+        Get-WinADCustomDiagramIcon -Name 'X' -CustomIcons @{ 'X' = @{ Wrong = 'key' } } | Should -BeNullOrEmpty
+        Get-WinADCustomDiagramIcon -Name 'X' -CustomIcons @{ 'X' = '' } | Should -BeNullOrEmpty
+    }
+    It 'matches names containing brackets when the pattern escapes them' {
+        (Get-WinADCustomDiagramIcon -Name 'Group[1]' -CustomIcons @{ 'Group`[1`]' = 'https://cdn/b.png' }).Image | Should -Be 'https://cdn/b.png'
+    }
+}
+
+Describe 'CustomIcons propagation through Show-WinADGroupMember' {
+    BeforeEach {
+        $Script:CapturedNodes = [System.Collections.Generic.List[object]]::new()
+        $Script:WinADCustomDiagramIconWarnings = $null
+        $Global:HTMLIcons = $null
+        # Pre-built membership rows exercise the visualize-only path without touching a directory
+        $Script:Rows = @(
+            New-TestRow -Name 'GG-RBAC-Root' -Nesting -1
+            New-TestRow -Name 'GG-RBAC-Sub'
+            New-TestRow -Name 'ADMIN-John' -Type 'User'
+            New-TestRow -Name 'Plain-User' -Type 'User'
+        )
+    }
+    It 'applies matching overrides on diagram nodes and leaves unmatched nodes on defaults' {
+        Show-WinADGroupMember -Identity $Script:Rows -HideHTML -CustomIcons ([ordered] @{
+                '*RBAC*'  = 'https://cdn/rbac.png'
+                'ADMIN-*' = @{ IconSolid = 'user-shield'; IconColor = 'Red' }
+            })
+        $Script:CapturedNodes.Count | Should -BeGreaterThan 0
+        $RbacNodes = @($Script:CapturedNodes | Where-Object { $_.Label -like 'GG-RBAC*' })
+        $RbacNodes.Count | Should -BeGreaterThan 0
+        $RbacNodes.Image | Should -Not -Contain $null
+        @($RbacNodes | Where-Object { $_.Image -ne 'https://cdn/rbac.png' }).Count | Should -Be 0
+        $AdminNodes = @($Script:CapturedNodes | Where-Object { $_.Label -like 'ADMIN-*' })
+        @($AdminNodes | Where-Object { $_.IconSolid -ne 'user-shield' -or $_.IconColor -ne 'Red' }).Count | Should -Be 0
+        $PlainNodes = @($Script:CapturedNodes | Where-Object { $_.Label -like 'Plain-*' })
+        @($PlainNodes | Where-Object { $_.Image -or $_.IconColor -eq 'Red' }).Count | Should -Be 0
+    }
+    It 'changes nothing when CustomIcons is omitted' {
+        Show-WinADGroupMember -Identity $Script:Rows -HideHTML
+        $Script:CapturedNodes.Count | Should -BeGreaterThan 0
+        @($Script:CapturedNodes | Where-Object { $_.Image -like 'https://cdn/*' }).Count | Should -Be 0
+    }
+}
+
+Describe 'CustomIcons propagation through Show-WinADGroupMemberOf' {
+    BeforeEach {
+        $Script:CapturedNodes = [System.Collections.Generic.List[object]]::new()
+        $Script:WinADCustomDiagramIconWarnings = $null
+        $Global:HTMLIcons = $null
+        $Script:TestGraph = @{}
+        foreach ($Definition in @(
+                @{ Name = 'GG-RBAC-Parent'; Members = @(Get-TestDN 'SomeUser'); MemberOf = @(); Class = 'group' }
+                @{ Name = 'SomeUser'; Members = @(); MemberOf = @(Get-TestDN 'GG-RBAC-Parent'); Class = 'user' }
+            )) {
+            $Script:TestGraph[(Get-TestDN $Definition.Name)] = [PSCustomObject] @{
+                Name              = $Definition.Name
+                SamAccountName    = $Definition.Name
+                DisplayName       = $Definition.Name
+                Mail              = ''
+                Enabled           = $true
+                ObjectClass       = $Definition.Class
+                GroupType         = 'Security'
+                GroupScope        = 'Universal'
+                DomainName        = 'test.local'
+                DistinguishedName = (Get-TestDN $Definition.Name)
+                ObjectSID         = "S-1-5-21-0-0-0-$($Definition.Name)"
+                Members           = $Definition.Members
+                MemberOf          = $Definition.MemberOf
+            }
+        }
+        $Script:WinADGroupObjectCache = @{}
+    }
+    It 'applies matching overrides on the memberOf diagram nodes' {
+        Show-WinADGroupMemberOf -Identity 'SomeUser' -HideHTML -CustomIcons @{ '*RBAC*' = 'https://cdn/rbac.png' }
+        $ParentNodes = @($Script:CapturedNodes | Where-Object { $_.Label -like 'GG-RBAC*' })
+        $ParentNodes.Count | Should -BeGreaterThan 0
+        @($ParentNodes | Where-Object { $_.Image -ne 'https://cdn/rbac.png' }).Count | Should -Be 0
+        $UserNodes = @($Script:CapturedNodes | Where-Object { $_.Label -like 'SomeUser*' })
+        @($UserNodes | Where-Object { $_.Image }).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
Fixes #35

Adds keyword-based custom node icons to the `Show-WinADGroupMember` / `Show-WinADGroupMemberOf` diagrams, as requested in #35 for environments with strict naming conventions.

## Usage

```powershell
Show-WinADGroupMember -GroupName 'Domain Admins' -Online -CustomIcons ([ordered] @{
    '*-RBAC-*'          = 'https://cdn-icons-png.flaticon.com/512/1687/1687242.png'   # image URL
    'Enterprise Admins' = @{ IconSolid = 'user-shield'; IconColor = 'Red' }           # Font Awesome icon + color
    '*ADMIN*'           = @{ Image = 'https://cdn-icons-png.flaticon.com/512/2206/2206368.png' }
})
```

- Keys are wildcard patterns matched against the object `Name` with `-like` (users, groups, computers, everything on the diagram).
- Values are either an image URL string, or a dictionary with `Image`, or `IconSolid`/`IconRegular`/`IconBrands` plus optional `IconColor` — so it works in both `-Online` (image icons) and default offline (Font Awesome) reports.
- First matching pattern wins; pass `[ordered] @{}` to control precedence. A mapping kept in a file works naturally: `-CustomIcons (Import-PowerShellDataFile .\IconMap.psd1)`.
- Objects without a match keep today's default icons, so existing reports are pixel-identical unless you opt in.

## Implementation

- New private helper `Get-WinADCustomDiagramIcon` resolves a name against the patterns and returns a ready-to-splat hashtable for `New-DiagramNode`, or `$null` for "use defaults". It validates icon names against PSWriteHTML's `$Global:HTMLIcons` dictionary (a typo would otherwise fail `New-DiagramNode`'s `ValidateScript` and silently drop the node while keeping its links) and skips invalid wildcard patterns — one warning per offender, then default icons.
- All 8 `New-HTMLGroup*Diagram*` builders accept `-CustomIcons`, resolve the override once per object, and check it before the existing `$Online`/offline branches, which are byte-for-byte unchanged. Per-site extras (`-Level`, `-ArrowsToEnabled`) are preserved, and group nodes replaced by a custom image keep their red/blue queried-vs-nested `ColorBorder` cue (deliberately omitted for `Icon*` overrides, where `ColorBorder` belongs to a different parameter set of `New-DiagramNode`).
- Both Show functions pass the dictionary through to all four diagrams they render (per-group and summary), with help + examples updated.

## Testing

A differential harness (stubbed PSWriteHTML commands capturing every `New-DiagramNode` call) runs all 8 builders against their master versions on PowerShell 7 and Windows PowerShell 5.1 — 224 assertions:

- without `-CustomIcons`, node sequences are **identical to master** in both `-Online` and offline modes for every builder;
- with overrides, matched nodes get exactly the mapped image/icon while unmatched nodes, entries with unusable values, unknown icon names, and invalid wildcard patterns all leave nodes byte-identical to the default run;
- icon-name validation was additionally verified against the real PSWriteHTML 1.38.0 `New-DiagramNode` parameter sets (the version pinned in the module manifest).

Possible follow-up (not included to keep the diff focused): `Show-WinADGroupCritical` and `Show-WinADUserSecurity` also render these diagrams and could forward the same parameter if you'd like parity there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
